### PR TITLE
chore: Bumping up `golangci-lint` to `1.64.6`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [opened, synchronized]
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [opened, synchronized]
 
 jobs:
   lint:
@@ -37,7 +38,7 @@ jobs:
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: golangci-lint Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.golanci-lint-cache }}
         key: ${{ runner.os }}-golangci-lint-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,9 @@ jobs:
         echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
         echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
+        # TODO: Make this less brittle.
+        echo "golanci-lint-cache=/home/runner/.cache/golangci-lint" >> "$GITHUB_OUTPUT"
+
     - name: Go Build Cache
       uses: actions/cache@v4
       with:
@@ -32,6 +35,12 @@ jobs:
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+    - name: golangci-lint Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.go-cache-paths.outputs.golanci-lint-cache }}
+        key: ${{ runner.os }}-golangci-lint-${{ hashFiles('**/go.sum') }}
 
     - name: Lint
       run: golangci-lint run ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [opened, synchronized]
 
 jobs:
   test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 10m
   issues-exit-code: 1
   tests: true
-  go: "1.23"
+  go: "1.24"
 output:
   formats:
     - format: colored-line-number

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.23.6"
-golangci-lint = "1.63.4"
+go = "1.24.1"
+golangci-lint = "1.64.6"


### PR DESCRIPTION
Also bumping go to `1.24.1`
