### PR TITLE
chore: Bump go to 1.24

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,114 +1,143 @@
+version: "2"
 run:
-  timeout: 10m
+  go: "1.24"
   issues-exit-code: 1
   tests: true
-  go: "1.24"
 output:
   formats:
-    - format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
-
-linters-settings:
-  staticcheck:
-    checks:
-      - all
-      - '-SA9005'
-  errcheck:
-    check-type-assertions: false
-    check-blank: false
-    exclude-functions:
-      - (*os.File).Close
-  errorlint:
-    errorf: true
-    asserts: true
-    comparison: true
-  gofmt:
-    simplify: true
-  dupl:
-    threshold: 120
-  goconst:
-    min-len: 3
-    min-occurrences: 5
-  revive:
-    min-confidence: 0.8
-  unused:
-    check-exported: false
-  unparam:
-    check-exported: false
-  nakedret:
-    max-func-lines: 20
-  gocritic:
-    disabled-checks:
-      - regexpMust
-      - rangeValCopy
-      - appendAssign
-      - hugeParam
-    enabled-tags:
-      - performance
-    disabled-tags:
-      - experimental
-
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
 linters:
   enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
     - dupl
-    - errcheck
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - fatcontext
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - goconst
     - gocritic
-    - goimports
-    - mnd
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
+    - gosmopolitan
+    - loggercheck
+    - makezero
     - misspell
-    - unconvert
-    - unused
-    - unparam
-    - wsl
+    - mnd
+    - musttag
+    - nilerr
+    - nilnesserr
+    - noctx
+    - paralleltest
+    - perfsprint
+    - prealloc
+    - protogetter
+    - reassign
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - testableexamples
+    - testifylint
+    - testpackage
     - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usetesting
     - wastedassign
-    - stylecheck
-
-  enable-all: false
+    - wsl
+    - zerologlint
   disable:
     - depguard
-    - gosec
-    - gocyclo
     - exhaustruct
+    - gocyclo
+    - gosec
     - nolintlint
-    - wrapcheck
+    - recvcheck
     - varnamelen
-
-  fast: false
-  mnd:
-    ignored-functions: strconv.Format*,os.*,strconv.Parse*,strings.SplitN,bytes.SplitN
-  presets:
-    - bugs
-    - performance
-    - unused
-    - test
-    # NOTE: These two are only in the strict lint right now
-    # - style
-    # - complexity
-
+    - wrapcheck
+  settings:
+    dupl:
+      threshold: 120
+    errcheck:
+      check-type-assertions: false
+      check-blank: false
+      exclude-functions:
+        - (*os.File).Close
+    errorlint:
+      errorf: true
+      asserts: true
+      comparison: true
+    goconst:
+      min-len: 3
+      min-occurrences: 5
+    gocritic:
+      disabled-checks:
+        - regexpMust
+        - rangeValCopy
+        - appendAssign
+        - hugeParam
+      enabled-tags:
+        - performance
+      disabled-tags:
+        - experimental
+    govet:
+      enable:
+        - fieldalignment
+    nakedret:
+      max-func-lines: 20
+    staticcheck:
+      checks:
+        - all
+        - -SA9005
+        - -QF1008
+        - -ST1001
+    unparam:
+      check-exported: false
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - dupl
+          - errcheck
+          - gocyclo
+          - lll
+          - mnd
+          - unparam
+          - wsl
+        path: _test\.go
+    paths:
+      - docs
+      - _ci
+      - .github
+      - .circleci
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  exclude-dirs:
-    - docs
-    - _ci
-    - .github
-    - .circleci
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - dupl
-        - gocyclo
-        - lll
-        - errcheck
-        - wsl
-        - mnd
-        - unparam
-
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+formatters:
+  enable:
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - docs
+      - _ci
+      - .github
+      - .circleci
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terragrunt-ls
 
-go 1.23.2
+go 1.24.4
 
 require (
 	github.com/gruntwork-io/terragrunt v0.77.22

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -111,10 +111,10 @@ func (s Scope) Add(node *IndexedNode) {
 type NodeIndex map[int][]*IndexedNode
 
 type nodeIndexBuilder struct {
-	stack    []*IndexedNode
 	index    NodeIndex
 	locals   Scope
 	includes Scope
+	stack    []*IndexedNode
 }
 
 func newNodeIndexBuilder() *nodeIndexBuilder {

--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -14,9 +14,9 @@ func TestParseHCLFile(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
+		expectedNodesAt map[hcl.Pos]string
 		name            string
 		contents        string
-		expectedNodesAt map[hcl.Pos]string
 	}{
 		{
 			name:     "empty hcl",
@@ -308,8 +308,8 @@ func TestGetNodeIncludeLabel(t *testing.T) {
 	tc := []struct {
 		name     string
 		content  string
-		pos      hcl.Pos
 		expected string
+		pos      hcl.Pos
 	}{
 		{
 			name: "not an include block",
@@ -366,8 +366,8 @@ func TestGetNodeDependencyLabel(t *testing.T) {
 	tc := []struct {
 		name     string
 		content  string
-		pos      hcl.Pos
 		expected string
+		pos      hcl.Pos
 	}{
 		{
 			name: "not a dependency block",
@@ -430,10 +430,10 @@ func TestFindFirstParentMatch(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
+		matcher  func(node *ast.IndexedNode) bool
 		name     string
 		content  string
 		pos      hcl.Pos
-		matcher  func(node *ast.IndexedNode) bool
 		expected bool
 	}{
 		{

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -17,10 +17,10 @@ type slogLogger struct {
 
 type Logger interface {
 	Close() error
-	Debug(msg string, args ...interface{})
-	Info(msg string, args ...interface{})
-	Warn(msg string, args ...interface{})
-	Error(msg string, args ...interface{})
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
 }
 
 // NewLogger builds the standard logger for terragrunt-ls.
@@ -68,21 +68,21 @@ func (l *slogLogger) Close() error {
 }
 
 // Debug logs a debug message
-func (l *slogLogger) Debug(msg string, args ...interface{}) {
+func (l *slogLogger) Debug(msg string, args ...any) {
 	l.Logger.Debug(msg, args...)
 }
 
 // Info logs an info message
-func (l *slogLogger) Info(msg string, args ...interface{}) {
+func (l *slogLogger) Info(msg string, args ...any) {
 	l.Logger.Info(msg, args...)
 }
 
 // Warn logs a warning message
-func (l *slogLogger) Warn(msg string, args ...interface{}) {
+func (l *slogLogger) Warn(msg string, args ...any) {
 	l.Logger.Warn(msg, args...)
 }
 
 // Error logs an error message
-func (l *slogLogger) Error(msg string, args ...interface{}) {
+func (l *slogLogger) Error(msg string, args ...any) {
 	l.Logger.Error(msg, args...)
 }

--- a/internal/lsp/initialize.go
+++ b/internal/lsp/initialize.go
@@ -8,8 +8,8 @@ type InitializeRequest struct {
 }
 
 type InitializeResponse struct {
-	Response
 	Result protocol.InitializeResult `json:"result"`
+	Response
 }
 
 type ServerInfo struct {

--- a/internal/lsp/message.go
+++ b/internal/lsp/message.go
@@ -2,13 +2,13 @@ package lsp
 
 type Request struct {
 	RPC    string `json:"jsonrpc"`
-	ID     int    `json:"id"`
 	Method string `json:"method"`
+	ID     int    `json:"id"`
 }
 
 type Response struct {
-	RPC string `json:"jsonrpc"`
 	ID  *int   `json:"id,omitempty"`
+	RPC string `json:"jsonrpc"`
 }
 
 type Notification struct {

--- a/internal/lsp/textdocument_completion.go
+++ b/internal/lsp/textdocument_completion.go
@@ -3,8 +3,8 @@ package lsp
 import "go.lsp.dev/protocol"
 
 type CompletionRequest struct {
-	Request
 	Params protocol.CompletionParams `json:"params"`
+	Request
 }
 
 type CompletionResponse struct {

--- a/internal/lsp/textdocument_definition.go
+++ b/internal/lsp/textdocument_definition.go
@@ -3,8 +3,8 @@ package lsp
 import "go.lsp.dev/protocol"
 
 type DefinitionRequest struct {
-	Request
 	Params protocol.DefinitionParams `json:"params"`
+	Request
 }
 
 type DefinitionResponse struct {

--- a/internal/lsp/textdocument_format.go
+++ b/internal/lsp/textdocument_format.go
@@ -3,8 +3,8 @@ package lsp
 import "go.lsp.dev/protocol"
 
 type FormatRequest struct {
-	Request
 	Params protocol.DocumentFormattingParams `json:"params"`
+	Request
 }
 
 type FormatResponse struct {

--- a/internal/lsp/textdocument_hover.go
+++ b/internal/lsp/textdocument_hover.go
@@ -3,8 +3,8 @@ package lsp
 import "go.lsp.dev/protocol"
 
 type HoverRequest struct {
-	Request
 	Params protocol.HoverParams `json:"params"`
+	Request
 }
 
 type HoverResponse struct {

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -74,21 +74,21 @@ func (l *testLogger) Close() error {
 }
 
 // Debug logs a debug message
-func (l *testLogger) Debug(msg string, args ...interface{}) {
+func (l *testLogger) Debug(msg string, args ...any) {
 	l.Logger.Debug(msg, args...)
 }
 
 // Info logs an info message
-func (l *testLogger) Info(msg string, args ...interface{}) {
+func (l *testLogger) Info(msg string, args ...any) {
 	l.Logger.Info(msg, args...)
 }
 
 // Warn logs a warning message
-func (l *testLogger) Warn(msg string, args ...interface{}) {
+func (l *testLogger) Warn(msg string, args ...any) {
 	l.Logger.Warn(msg, args...)
 }
 
 // Error logs an error message
-func (l *testLogger) Error(msg string, args ...interface{}) {
+func (l *testLogger) Error(msg string, args ...any) {
 	l.Logger.Error(msg, args...)
 }

--- a/internal/tg/completion/completion_test.go
+++ b/internal/tg/completion/completion_test.go
@@ -14,10 +14,10 @@ func TestGetCompletions(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
-		name        string
 		store       store.Store
-		position    protocol.Position
+		name        string
 		completions []protocol.CompletionItem
+		position    protocol.Position
 	}{
 		{
 			name: "complete dep",

--- a/internal/tg/definition/definition_test.go
+++ b/internal/tg/definition/definition_test.go
@@ -16,9 +16,9 @@ func TestGetDefinitionTargetWithContext(t *testing.T) {
 	tc := []struct {
 		name            string
 		document        string
-		position        protocol.Position
 		expectedTarget  string
 		expectedContext string
+		position        protocol.Position
 	}{
 		{
 			name:            "empty store",

--- a/internal/tg/hover/hover_test.go
+++ b/internal/tg/hover/hover_test.go
@@ -14,11 +14,11 @@ func TestGetHoverTargetWithContext(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
-		name            string
 		store           store.Store
-		position        protocol.Position
+		name            string
 		expectedTarget  string
 		expectedContext string
+		position        protocol.Position
 	}{
 		{
 			name:            "empty document",

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -16,10 +16,10 @@ func TestParseTerragruntBuffer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		setup    func(t *testing.T, tmpDir string) string // returns the path to the file to parse
-		content  string
+		setup    func(t *testing.T, tmpDir string) string
 		wantCfg  *config.TerragruntConfig
+		name     string
+		content  string
 		wantDiag bool
 	}{
 		{

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -67,12 +67,12 @@ func TestState_OpenDocument(t *testing.T) {
 	foo = "bar"
 }`,
 			expected: &config.TerragruntConfig{
-				Locals: map[string]interface{}{
+				Locals: map[string]any{
 					"foo": "bar",
 				},
 				GenerateConfigs:   map[string]codegen.GenerateConfig{},
 				ProcessedIncludes: config.IncludeConfigsMap{},
-				FieldsMetadata: map[string]map[string]interface{}{
+				FieldsMetadata: map[string]map[string]any{
 					"locals-foo": {
 						"found_in_file": unitPath,
 					},
@@ -86,13 +86,13 @@ func TestState_OpenDocument(t *testing.T) {
 	baz = "qux"
 }`,
 			expected: &config.TerragruntConfig{
-				Locals: map[string]interface{}{
+				Locals: map[string]any{
 					"baz": "qux",
 					"foo": "bar",
 				},
 				GenerateConfigs:   map[string]codegen.GenerateConfig{},
 				ProcessedIncludes: config.IncludeConfigsMap{},
-				FieldsMetadata: map[string]map[string]interface{}{
+				FieldsMetadata: map[string]map[string]any{
 					"locals-baz": {
 						"found_in_file": unitPath,
 					},
@@ -144,9 +144,9 @@ func TestState_UpdateDocument(t *testing.T) {
 	tc := []struct {
 		name            string
 		document        string
-		expected        map[string]interface{}
+		expected        map[string]any
 		updated         string
-		expectedUpdated map[string]interface{}
+		expectedUpdated map[string]any
 	}{
 		{
 			name:     "empty document",
@@ -157,13 +157,13 @@ func TestState_UpdateDocument(t *testing.T) {
 			document: `locals {
 	foo = "bar"
 }`,
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
 			},
 			updated: `locals {
 	foo = "baz"
 }`,
-			expectedUpdated: map[string]interface{}{
+			expectedUpdated: map[string]any{
 				"foo": "baz",
 			},
 		},
@@ -173,7 +173,7 @@ func TestState_UpdateDocument(t *testing.T) {
 	foo = "bar"
 	baz = "qux"
 }`,
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
 				"baz": "qux",
 			},
@@ -181,7 +181,7 @@ func TestState_UpdateDocument(t *testing.T) {
 	foo = "baz"
 	baz = "qux"
 }`,
-			expectedUpdated: map[string]interface{}{
+			expectedUpdated: map[string]any{
 				"foo": "baz",
 				"baz": "qux",
 			},

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -49,9 +49,9 @@ func TestState_OpenDocument(t *testing.T) {
 	unitURI := uri.File(unitPath)
 
 	tc := []struct {
+		expected *config.TerragruntConfig
 		name     string
 		document string
-		expected *config.TerragruntConfig
 	}{
 		{
 			name:     "empty document",
@@ -142,11 +142,11 @@ func TestState_UpdateDocument(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
+		expected        map[string]any
+		expectedUpdated map[string]any
 		name            string
 		document        string
-		expected        map[string]any
 		updated         string
-		expectedUpdated map[string]any
 	}{
 		{
 			name:     "empty document",
@@ -221,10 +221,10 @@ func TestState_Hover(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
+		expected lsp.HoverResponse
 		name     string
 		document string
 		position protocol.Position
-		expected lsp.HoverResponse
 	}{
 		{
 			name: "simple locals",
@@ -328,8 +328,8 @@ func TestState_Definition(t *testing.T) {
 	tc := []struct {
 		name     string
 		document string
-		position protocol.Position
 		expected lsp.DefinitionResponse
+		position protocol.Position
 	}{
 		{
 			name: "nothing to jump to",
@@ -447,8 +447,8 @@ func TestState_TextDocumentCompletion(t *testing.T) {
 		name              string
 		initial           string
 		document          string
-		position          protocol.Position
 		expected          lsp.CompletionResponse
+		position          protocol.Position
 		expectDiagnostics bool
 	}{
 		{

--- a/internal/tg/text/text_test.go
+++ b/internal/tg/text/text_test.go
@@ -14,8 +14,8 @@ func TestGetCursorWord(t *testing.T) {
 	tc := []struct {
 		name     string
 		document string
-		position protocol.Position
 		expected string
+		position protocol.Position
 	}{
 		{
 			name:     "simple word",

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-go = "1.24.1"
-golangci-lint = "1.64.6"
+go = "1.24.4"
+golangci-lint = "2.1.6"
 lua = "5.4.7"
 node = "23.10.0"
 rust = "1.85.1"


### PR DESCRIPTION
Taking care of some housekeeping to get project on go 1.24 in go.mod, etc.

Also updated `.golangci.yml` file to track the Terragrunt repo, and ran the `gopls` and `golangci-lint` auto-fix commands.
