### PR TITLE
feat: Add support for terragrunt.stack.hcl and terragrunt.values.hcl

### DIFF
--- a/internal/tg/completion/completion.go
+++ b/internal/tg/completion/completion.go
@@ -16,8 +16,8 @@ func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) 
 	var candidates []protocol.CompletionItem
 
 	switch s.FileType {
-	case store.FileTypeTerragrunt:
-		candidates = newTerragruntCompletions(position)
+	case store.FileTypeUnit:
+		candidates = newUnitCompletions(position)
 	case store.FileTypeStack:
 		candidates = newStackCompletions(position)
 	case store.FileTypeValues:
@@ -37,11 +37,11 @@ func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) 
 	return completions
 }
 
-// newTerragruntCompletions returns a list of completions for terragrunt.hcl files.
+// newUnitCompletions returns a list of completions for terragrunt.hcl files.
 //
 // TODO: Add detection via the AST index to determine
 // whether the cursor is in the context of a block or expression.
-func newTerragruntCompletions(position protocol.Position) []protocol.CompletionItem {
+func newUnitCompletions(position protocol.Position) []protocol.CompletionItem {
 	return []protocol.CompletionItem{
 		{
 			Label: "dependency",

--- a/internal/tg/completion/completion.go
+++ b/internal/tg/completion/completion.go
@@ -16,12 +16,12 @@ func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) 
 	var candidates []protocol.CompletionItem
 
 	switch s.FileType {
+	case store.FileTypeTerragrunt:
+		candidates = newTerragruntCompletions(position)
 	case store.FileTypeStack:
 		candidates = newStackCompletions(position)
 	case store.FileTypeValues:
 		return []protocol.CompletionItem{}
-	default:
-		candidates = newTerragruntCompletions(position)
 	}
 
 	completions := []protocol.CompletionItem{}

--- a/internal/tg/completion/completion.go
+++ b/internal/tg/completion/completion.go
@@ -10,11 +10,23 @@ import (
 	"go.lsp.dev/protocol"
 )
 
-func GetCompletions(l logger.Logger, store store.Store, position protocol.Position) []protocol.CompletionItem {
-	word := text.GetCursorWord(store.Document, position)
+func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) []protocol.CompletionItem {
+	word := text.GetCursorWord(s.Document, position)
+
+	var candidates []protocol.CompletionItem
+
+	switch s.FileType {
+	case store.FileTypeStack:
+		candidates = newStackCompletions(position)
+	case store.FileTypeValues:
+		return []protocol.CompletionItem{}
+	default:
+		candidates = newTerragruntCompletions(position)
+	}
+
 	completions := []protocol.CompletionItem{}
 
-	for _, completion := range newCompletions(position) {
+	for _, completion := range candidates {
 		if strings.HasPrefix(completion.Label, word) {
 			completions = append(completions, completion)
 		}
@@ -23,11 +35,11 @@ func GetCompletions(l logger.Logger, store store.Store, position protocol.Positi
 	return completions
 }
 
-// newCompletions returns a list of completions for the given position.
+// newTerragruntCompletions returns a list of completions for terragrunt.hcl files.
 //
 // TODO: Add detection via the AST index to determine
 // whether the cursor is in the context of a block or expression.
-func newCompletions(position protocol.Position) []protocol.CompletionItem {
+func newTerragruntCompletions(position protocol.Position) []protocol.CompletionItem {
 	return []protocol.CompletionItem{
 		{
 			Label: "dependency",
@@ -403,6 +415,71 @@ The terragrunt_version_constraint attribute is used to specify which versions of
 					End:   protocol.Position{Line: position.Line, Character: position.Character},
 				},
 				NewText: `terragrunt_version_constraint = ">= ${1:0.23}"`,
+			},
+		},
+	}
+}
+
+// newStackCompletions returns a list of completions for terragrunt.stack.hcl files.
+func newStackCompletions(position protocol.Position) []protocol.CompletionItem {
+	return []protocol.CompletionItem{
+		{
+			Label: "unit",
+			Documentation: protocol.MarkupContent{
+				Kind: protocol.Markdown,
+				Value: `# unit
+The unit block references a Terragrunt unit to include in this stack.`,
+			},
+			Kind:             protocol.CompletionItemKindClass,
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+			TextEdit: &protocol.TextEdit{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: position.Line, Character: 0},
+					End:   protocol.Position{Line: position.Line, Character: position.Character},
+				},
+				NewText: `unit "${1}" {
+	source = "${2}"
+	path   = "${3}"
+}`,
+			},
+		},
+		{
+			Label: "stack",
+			Documentation: protocol.MarkupContent{
+				Kind: protocol.Markdown,
+				Value: `# stack
+The stack block references another Terragrunt stack to nest within this stack.`,
+			},
+			Kind:             protocol.CompletionItemKindClass,
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+			TextEdit: &protocol.TextEdit{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: position.Line, Character: 0},
+					End:   protocol.Position{Line: position.Line, Character: position.Character},
+				},
+				NewText: `stack "${1}" {
+	source = "${2}"
+	path   = "${3}"
+}`,
+			},
+		},
+		{
+			Label: "locals",
+			Documentation: protocol.MarkupContent{
+				Kind: protocol.Markdown,
+				Value: `# locals
+The locals block defines aliases for expressions reusable within the stack file.`,
+			},
+			Kind:             protocol.CompletionItemKindClass,
+			InsertTextFormat: protocol.InsertTextFormatSnippet,
+			TextEdit: &protocol.TextEdit{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: position.Line, Character: 0},
+					End:   protocol.Position{Line: position.Line, Character: position.Character},
+				},
+				NewText: `locals {
+	${1} = ${2}
+}`,
 			},
 		},
 	}

--- a/internal/tg/completion/completion.go
+++ b/internal/tg/completion/completion.go
@@ -22,6 +22,8 @@ func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) 
 		candidates = newStackCompletions(position)
 	case store.FileTypeValues:
 		return []protocol.CompletionItem{}
+	case store.FileTypeUnknown:
+		return []protocol.CompletionItem{}
 	}
 
 	completions := []protocol.CompletionItem{}

--- a/internal/tg/completion/completion_test.go
+++ b/internal/tg/completion/completion_test.go
@@ -23,6 +23,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete dep",
 			store: store.Store{
 				Document: `dep`,
+				FileType: store.FileTypeTerragrunt,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -68,6 +69,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete dependency",
 			store: store.Store{
 				Document: `dependency`,
+				FileType: store.FileTypeTerragrunt,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -95,6 +97,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete include",
 			store: store.Store{
 				Document: `in`,
+				FileType: store.FileTypeTerragrunt,
 			},
 			position: protocol.Position{Line: 0, Character: 1},
 			completions: []protocol.CompletionItem{
@@ -140,6 +143,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete include",
 			store: store.Store{
 				Document: `include`,
+				FileType: store.FileTypeTerragrunt,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -167,6 +171,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete generate",
 			store: store.Store{
 				Document: `generate`,
+				FileType: store.FileTypeTerragrunt,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -249,6 +254,34 @@ EOF
 						NewText: `stack "${1}" {
 	source = "${2}"
 	path   = "${3}"
+}`,
+					},
+				},
+			},
+		},
+		{
+			name: "stack file - complete locals",
+			store: store.Store{
+				Document: `lo`,
+				FileType: store.FileTypeStack,
+			},
+			position: protocol.Position{Line: 0, Character: 2},
+			completions: []protocol.CompletionItem{
+				{
+					Label: "locals",
+					Documentation: protocol.MarkupContent{
+						Kind:  protocol.Markdown,
+						Value: "# locals\nThe locals block defines aliases for expressions reusable within the stack file.",
+					},
+					Kind:             protocol.CompletionItemKindClass,
+					InsertTextFormat: protocol.InsertTextFormatSnippet,
+					TextEdit: &protocol.TextEdit{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 0, Character: 0},
+							End:   protocol.Position{Line: 0, Character: 2},
+						},
+						NewText: `locals {
+	${1} = ${2}
 }`,
 					},
 				},

--- a/internal/tg/completion/completion_test.go
+++ b/internal/tg/completion/completion_test.go
@@ -23,7 +23,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete dep",
 			store: store.Store{
 				Document: `dep`,
-				FileType: store.FileTypeTerragrunt,
+				FileType: store.FileTypeUnit,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -69,7 +69,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete dependency",
 			store: store.Store{
 				Document: `dependency`,
-				FileType: store.FileTypeTerragrunt,
+				FileType: store.FileTypeUnit,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -97,7 +97,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete include",
 			store: store.Store{
 				Document: `in`,
-				FileType: store.FileTypeTerragrunt,
+				FileType: store.FileTypeUnit,
 			},
 			position: protocol.Position{Line: 0, Character: 1},
 			completions: []protocol.CompletionItem{
@@ -143,7 +143,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete include",
 			store: store.Store{
 				Document: `include`,
-				FileType: store.FileTypeTerragrunt,
+				FileType: store.FileTypeUnit,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{
@@ -171,7 +171,7 @@ func TestGetCompletions(t *testing.T) {
 			name: "complete generate",
 			store: store.Store{
 				Document: `generate`,
-				FileType: store.FileTypeTerragrunt,
+				FileType: store.FileTypeUnit,
 			},
 			position: protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{

--- a/internal/tg/completion/completion_test.go
+++ b/internal/tg/completion/completion_test.go
@@ -196,6 +196,73 @@ EOF
 				},
 			},
 		},
+		{
+			name: "stack file - complete unit",
+			store: store.Store{
+				Document: `uni`,
+				FileType: store.FileTypeStack,
+			},
+			position: protocol.Position{Line: 0, Character: 3},
+			completions: []protocol.CompletionItem{
+				{
+					Label: "unit",
+					Documentation: protocol.MarkupContent{
+						Kind:  protocol.Markdown,
+						Value: "# unit\nThe unit block references a Terragrunt unit to include in this stack.",
+					},
+					Kind:             protocol.CompletionItemKindClass,
+					InsertTextFormat: protocol.InsertTextFormatSnippet,
+					TextEdit: &protocol.TextEdit{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 0, Character: 0},
+							End:   protocol.Position{Line: 0, Character: 3},
+						},
+						NewText: `unit "${1}" {
+	source = "${2}"
+	path   = "${3}"
+}`,
+					},
+				},
+			},
+		},
+		{
+			name: "stack file - complete stack",
+			store: store.Store{
+				Document: `sta`,
+				FileType: store.FileTypeStack,
+			},
+			position: protocol.Position{Line: 0, Character: 3},
+			completions: []protocol.CompletionItem{
+				{
+					Label: "stack",
+					Documentation: protocol.MarkupContent{
+						Kind:  protocol.Markdown,
+						Value: "# stack\nThe stack block references another Terragrunt stack to nest within this stack.",
+					},
+					Kind:             protocol.CompletionItemKindClass,
+					InsertTextFormat: protocol.InsertTextFormatSnippet,
+					TextEdit: &protocol.TextEdit{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 0, Character: 0},
+							End:   protocol.Position{Line: 0, Character: 3},
+						},
+						NewText: `stack "${1}" {
+	source = "${2}"
+	path   = "${3}"
+}`,
+					},
+				},
+			},
+		},
+		{
+			name: "values file - no completions",
+			store: store.Store{
+				Document: `loc`,
+				FileType: store.FileTypeValues,
+			},
+			position:    protocol.Position{Line: 0, Character: 3},
+			completions: []protocol.CompletionItem{},
+		},
 	}
 
 	for _, tt := range tc {

--- a/internal/tg/hover/hover_test.go
+++ b/internal/tg/hover/hover_test.go
@@ -14,10 +14,10 @@ func TestGetHoverTargetWithContext(t *testing.T) {
 	t.Parallel()
 
 	tc := []struct {
-		store           store.Store
 		name            string
 		expectedTarget  string
 		expectedContext string
+		store           store.Store
 		position        protocol.Position
 	}{
 		{

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -249,7 +249,7 @@ func DetectFileType(filename string) store.FileType {
 
 	switch base {
 	case "terragrunt.hcl":
-		return store.FileTypeTerragrunt
+		return store.FileTypeUnit
 	case "terragrunt.stack.hcl":
 		return store.FileTypeStack
 	case "terragrunt.values.hcl":

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -173,12 +173,14 @@ func DetectFileType(filename string) store.FileType {
 	base := filepath.Base(filename)
 
 	switch base {
+	case "terragrunt.hcl":
+		return store.FileTypeTerragrunt
 	case "terragrunt.stack.hcl":
 		return store.FileTypeStack
 	case "terragrunt.values.hcl":
 		return store.FileTypeValues
 	default:
-		return store.FileTypeTerragrunt
+		return store.FileTypeUnknown
 	}
 }
 

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -184,31 +184,21 @@ func DetectFileType(filename string) store.FileType {
 
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
 func ParseStackBuffer(l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
-	opts, err := options.NewTerragruntOptionsWithConfigPath(filename)
-	if err != nil {
-		return nil, []protocol.Diagnostic{
-			{
-				Range: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 0},
-					End:   protocol.Position{Line: 0, Character: 0},
-				},
-				Message:  err.Error(),
-				Severity: protocol.DiagnosticSeverityError,
-				Source:   "HCL",
-			},
-		}
-	}
-
-	opts.SkipOutput = true
-	opts.NonInteractive = true
-
 	tgLogger := tgLog.New(
 		tgLog.WithOutput(l.Writer()),
 		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
 		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
 	)
 
-	cfg, err := config.ReadStackConfigString(context.TODO(), tgLogger, opts, filename, text, nil)
+	ctx, pctx := config.NewParsingContext(context.TODO(), tgLogger)
+	pctx.TerragruntConfigPath = filename
+	pctx.WorkingDir = filepath.Dir(filename)
+	pctx.SkipOutput = true
+	pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
+	pctx.Writers.Writer = io.Discard
+	pctx.Writers.ErrWriter = io.Discard
+
+	cfg, err := config.ReadStackConfigString(ctx, tgLogger, pctx, filename, text, nil)
 	if err != nil {
 		l.Error("Error parsing stack config", "error", err)
 

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -186,6 +186,15 @@ func DetectFileType(filename string) store.FileType {
 
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
 func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
+	var parseDiags hcl.Diagnostics
+
+	parseOptions := []hclparse.Option{
+		hclparse.WithDiagnosticsHandler(func(file *hcl.File, hclDiags hcl.Diagnostics) (hcl.Diagnostics, error) {
+			parseDiags = append(parseDiags, hclDiags...)
+			return hclDiags, nil
+		}),
+	}
+
 	tgLogger := tgLog.New(
 		tgLog.WithOutput(l.Writer()),
 		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
@@ -199,23 +208,17 @@ func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text strin
 	pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
 	pctx.Writers.Writer = io.Discard
 	pctx.Writers.ErrWriter = io.Discard
+	pctx.ParserOptions = append(pctx.ParserOptions, parseOptions...)
 
 	cfg, err := config.ReadStackConfigString(ctx, tgLogger, pctx, filename, text, nil)
 	if err != nil {
+		// Just log the error for now
 		l.Error("Error parsing stack config", "error", err)
-
-		return cfg, []protocol.Diagnostic{
-			{
-				Range: protocol.Range{
-					Start: protocol.Position{Line: 0, Character: 0},
-					End:   protocol.Position{Line: 0, Character: 0},
-				},
-				Message:  err.Error(),
-				Severity: protocol.DiagnosticSeverityError,
-				Source:   "HCL",
-			},
-		}
 	}
 
-	return cfg, []protocol.Diagnostic{}
+	filteredDiags := filterHCLDiags(l, parseDiags, filename)
+
+	diags := hclDiagsToLSPDiags(filteredDiags)
+
+	return cfg, diags
 }

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -107,9 +107,9 @@ func filterHCLDiags(l logger.Logger, diags hcl.Diagnostics, filename, text strin
 			continue
 		}
 
-		if isValuesAttributeDiag(diag, text) {
+		if isUnresolvableAttributeDiag(diag, text) {
 			l.Debug(
-				"Filtering values attribute diag",
+				"Filtering unresolvable attribute diag",
 				"diag", diag,
 				"filename", filename,
 			)
@@ -162,8 +162,6 @@ func isParentFileNotFoundDiag(diag *hcl.Diagnostic) bool {
 }
 
 const (
-	valuesKeyword = "values"
-
 	// UnknownVariableSummary is the summary for an unknown variable diagnostic.
 	UnknownVariableSummary = "Unknown variable"
 
@@ -171,11 +169,16 @@ const (
 	ValuesUnknownVariableDetail = `There is no variable named "values".`
 )
 
-// isValuesAttributeDiag checks whether the diagnostic is an "Unsupported attribute"
-// or "Unknown variable" error caused by referencing the `values` object, which is
-// populated at runtime from terragrunt.values.hcl and cannot be resolved during
-// LS parsing.
-func isValuesAttributeDiag(diag *hcl.Diagnostic, text string) bool {
+// unresolvableKeywords lists object names whose attributes may not be
+// available during LS parsing because they depend on runtime state:
+//   - "values": populated from terragrunt.values.hcl at runtime.
+//   - "local": locals that reference unresolvable values cascade failures.
+var unresolvableKeywords = []string{"values", "local"}
+
+// isUnresolvableAttributeDiag checks whether the diagnostic is an "Unsupported
+// attribute" or "Unknown variable" error caused by referencing an object that
+// cannot be fully resolved during LS parsing.
+func isUnresolvableAttributeDiag(diag *hcl.Diagnostic, text string) bool {
 	if diag.Summary == UnknownVariableSummary && diag.Detail == ValuesUnknownVariableDetail {
 		return true
 	}
@@ -191,16 +194,23 @@ func isValuesAttributeDiag(diag *hcl.Diagnostic, text string) bool {
 		return false
 	}
 
-	// The diagnostic start column points to the "." in "values.attr".
-	// Check that the characters immediately before the dot spell "values".
+	// The diagnostic start column points to the "." in "keyword.attr".
+	// Check that the characters immediately before the dot match a known keyword.
 	col := diag.Subject.Start.Column - 1 // HCL columns are 1-based, convert to 0-based
-	keywordLen := len(valuesKeyword)
 
-	if col < keywordLen {
-		return false
+	for _, keyword := range unresolvableKeywords {
+		kLen := len(keyword)
+
+		if col < kLen {
+			continue
+		}
+
+		if lines[line][col-kLen:col] == keyword {
+			return true
+		}
 	}
 
-	return lines[line][col-keywordLen:col] == valuesKeyword
+	return false
 }
 
 func hclDiagsToLSPDiags(hclDiags hcl.Diagnostics) []protocol.Diagnostic {

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/tg/store"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/gruntwork-io/terragrunt/pkg/config/hclparse"
@@ -165,4 +166,64 @@ func hclDiagsToLSPDiags(hclDiags hcl.Diagnostics) []protocol.Diagnostic {
 	}
 
 	return diags
+}
+
+// DetectFileType returns the FileType for the given filename based on its base name.
+func DetectFileType(filename string) store.FileType {
+	base := filepath.Base(filename)
+
+	switch base {
+	case "terragrunt.stack.hcl":
+		return store.FileTypeStack
+	case "terragrunt.values.hcl":
+		return store.FileTypeValues
+	default:
+		return store.FileTypeTerragrunt
+	}
+}
+
+// ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
+func ParseStackBuffer(l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
+	opts, err := options.NewTerragruntOptionsWithConfigPath(filename)
+	if err != nil {
+		return nil, []protocol.Diagnostic{
+			{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 0, Character: 0},
+					End:   protocol.Position{Line: 0, Character: 0},
+				},
+				Message:  err.Error(),
+				Severity: protocol.DiagnosticSeverityError,
+				Source:   "HCL",
+			},
+		}
+	}
+
+	opts.SkipOutput = true
+	opts.NonInteractive = true
+
+	tgLogger := tgLog.New(
+		tgLog.WithOutput(l.Writer()),
+		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
+		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
+	)
+
+	cfg, err := config.ReadStackConfigString(context.TODO(), tgLogger, opts, filename, text, nil)
+	if err != nil {
+		l.Error("Error parsing stack config", "error", err)
+
+		return cfg, []protocol.Diagnostic{
+			{
+				Range: protocol.Range{
+					Start: protocol.Position{Line: 0, Character: 0},
+					End:   protocol.Position{Line: 0, Character: 0},
+				},
+				Message:  err.Error(),
+				Severity: protocol.DiagnosticSeverityError,
+				Source:   "HCL",
+			},
+		}
+	}
+
+	return cfg, []protocol.Diagnostic{}
 }

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -51,14 +51,14 @@ func ParseTerragruntBuffer(ctx context.Context, l logger.Logger, filename, text 
 		l.Error("Error parsing Terragrunt config", "error", err)
 	}
 
-	filteredDiags := filterHCLDiags(l, parseDiags, filename)
+	filteredDiags := filterHCLDiags(l, parseDiags, filename, text)
 
 	diags := hclDiagsToLSPDiags(filteredDiags)
 
 	return cfg, diags
 }
 
-func filterHCLDiags(l logger.Logger, diags hcl.Diagnostics, filename string) hcl.Diagnostics {
+func filterHCLDiags(l logger.Logger, diags hcl.Diagnostics, filename, text string) hcl.Diagnostics {
 	filtered := hcl.Diagnostics{}
 
 	for _, diag := range diags {
@@ -87,6 +87,16 @@ func filterHCLDiags(l logger.Logger, diags hcl.Diagnostics, filename string) hcl
 		if isParentFileNotFoundDiag(diag) {
 			l.Debug(
 				"Filtering parent file not found diag",
+				"diag", diag,
+				"filename", filename,
+			)
+
+			continue
+		}
+
+		if isValuesAttributeDiag(diag, text) {
+			l.Debug(
+				"Filtering values attribute diag",
 				"diag", diag,
 				"filename", filename,
 			)
@@ -136,6 +146,46 @@ func isParentFileNotFoundDiag(diag *hcl.Diagnostic) bool {
 	}
 
 	return strings.HasPrefix(diag.Detail, ParentFileNotFoundErrorDetailPartial)
+}
+
+const (
+	valuesPrefix = "values."
+
+	// UnknownVariableSummary is the summary for an unknown variable diagnostic.
+	UnknownVariableSummary = "Unknown variable"
+
+	// ValuesUnknownVariableDetail is the detail for a missing "values" variable diagnostic.
+	ValuesUnknownVariableDetail = `There is no variable named "values".`
+)
+
+// isValuesAttributeDiag checks whether the diagnostic is an "Unsupported attribute"
+// or "Unknown variable" error caused by referencing the `values` object, which is
+// populated at runtime from terragrunt.values.hcl and cannot be resolved during
+// LS parsing.
+func isValuesAttributeDiag(diag *hcl.Diagnostic, text string) bool {
+	if diag.Summary == UnknownVariableSummary && diag.Detail == ValuesUnknownVariableDetail {
+		return true
+	}
+
+	if diag.Summary != UnsupportedAttributeSummary {
+		return false
+	}
+
+	lines := strings.Split(text, "\n")
+	line := diag.Subject.Start.Line - 1 // HCL lines are 1-based
+
+	if line < 0 || line >= len(lines) {
+		return false
+	}
+
+	col := diag.Subject.Start.Column - 1 // HCL columns are 1-based
+	prefixLen := len(valuesPrefix)
+
+	if col < prefixLen {
+		return false
+	}
+
+	return lines[line][col-prefixLen:col] == valuesPrefix
 }
 
 func hclDiagsToLSPDiags(hclDiags hcl.Diagnostics) []protocol.Diagnostic {
@@ -216,7 +266,7 @@ func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text strin
 		l.Error("Error parsing stack config", "error", err)
 	}
 
-	filteredDiags := filterHCLDiags(l, parseDiags, filename)
+	filteredDiags := filterHCLDiags(l, parseDiags, filename, text)
 
 	diags := hclDiagsToLSPDiags(filteredDiags)
 

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -20,38 +20,51 @@ import (
 
 const defaultMaxFoldersToCheck = 100
 
-func ParseTerragruntBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.TerragruntConfig, []protocol.Diagnostic) {
-	var parseDiags hcl.Diagnostics
+// parsingSetup holds the shared state for parsing terragrunt config files.
+type parsingSetup struct {
+	pctx       *config.ParsingContext
+	tgLogger   tgLog.Logger
+	parseDiags hcl.Diagnostics
+}
+
+func newParsingSetup(ctx context.Context, l logger.Logger, filename string) (context.Context, *parsingSetup) {
+	s := &parsingSetup{}
 
 	parseOptions := []hclparse.Option{
 		hclparse.WithDiagnosticsHandler(func(file *hcl.File, hclDiags hcl.Diagnostics) (hcl.Diagnostics, error) {
-			parseDiags = append(parseDiags, hclDiags...)
+			s.parseDiags = append(s.parseDiags, hclDiags...)
 			return hclDiags, nil
 		}),
 	}
 
-	tgLogger := tgLog.New(
+	s.tgLogger = tgLog.New(
 		tgLog.WithOutput(l.Writer()),
 		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
 		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
 	)
 
-	ctx, pctx := config.NewParsingContext(ctx, tgLogger)
-	pctx.TerragruntConfigPath = filename
-	pctx.WorkingDir = filepath.Dir(filename)
-	pctx.SkipOutput = true
-	pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
-	pctx.Writers.Writer = io.Discard
-	pctx.Writers.ErrWriter = io.Discard
-	pctx.ParserOptions = append(pctx.ParserOptions, parseOptions...)
+	ctx, s.pctx = config.NewParsingContext(ctx, s.tgLogger)
+	s.pctx.TerragruntConfigPath = filename
+	s.pctx.WorkingDir = filepath.Dir(filename)
+	s.pctx.SkipOutput = true
+	s.pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
+	s.pctx.Writers.Writer = io.Discard
+	s.pctx.Writers.ErrWriter = io.Discard
+	s.pctx.ParserOptions = append(s.pctx.ParserOptions, parseOptions...)
 
-	cfg, err := config.ParseConfigString(ctx, pctx, tgLogger, filename, text, nil)
+	return ctx, s
+}
+
+func ParseTerragruntBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.TerragruntConfig, []protocol.Diagnostic) {
+	ctx, s := newParsingSetup(ctx, l, filename)
+
+	cfg, err := config.ParseConfigString(ctx, s.pctx, s.tgLogger, filename, text, nil)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing Terragrunt config", "error", err)
 	}
 
-	filteredDiags := filterHCLDiags(l, parseDiags, filename, text)
+	filteredDiags := filterHCLDiags(l, s.parseDiags, filename, text)
 
 	diags := hclDiagsToLSPDiags(filteredDiags)
 
@@ -149,7 +162,7 @@ func isParentFileNotFoundDiag(diag *hcl.Diagnostic) bool {
 }
 
 const (
-	valuesPrefix = "values."
+	valuesKeyword = "values"
 
 	// UnknownVariableSummary is the summary for an unknown variable diagnostic.
 	UnknownVariableSummary = "Unknown variable"
@@ -178,14 +191,16 @@ func isValuesAttributeDiag(diag *hcl.Diagnostic, text string) bool {
 		return false
 	}
 
-	col := diag.Subject.Start.Column - 1 // HCL columns are 1-based
-	prefixLen := len(valuesPrefix)
+	// The diagnostic start column points to the "." in "values.attr".
+	// Check that the characters immediately before the dot spell "values".
+	col := diag.Subject.Start.Column - 1 // HCL columns are 1-based, convert to 0-based
+	keywordLen := len(valuesKeyword)
 
-	if col < prefixLen {
+	if col < keywordLen {
 		return false
 	}
 
-	return lines[line][col-prefixLen:col] == valuesPrefix
+	return lines[line][col-keywordLen:col] == valuesKeyword
 }
 
 func hclDiagsToLSPDiags(hclDiags hcl.Diagnostics) []protocol.Diagnostic {
@@ -236,37 +251,15 @@ func DetectFileType(filename string) store.FileType {
 
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
 func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
-	var parseDiags hcl.Diagnostics
+	ctx, s := newParsingSetup(ctx, l, filename)
 
-	parseOptions := []hclparse.Option{
-		hclparse.WithDiagnosticsHandler(func(file *hcl.File, hclDiags hcl.Diagnostics) (hcl.Diagnostics, error) {
-			parseDiags = append(parseDiags, hclDiags...)
-			return hclDiags, nil
-		}),
-	}
-
-	tgLogger := tgLog.New(
-		tgLog.WithOutput(l.Writer()),
-		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
-		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
-	)
-
-	ctx, pctx := config.NewParsingContext(ctx, tgLogger)
-	pctx.TerragruntConfigPath = filename
-	pctx.WorkingDir = filepath.Dir(filename)
-	pctx.SkipOutput = true
-	pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
-	pctx.Writers.Writer = io.Discard
-	pctx.Writers.ErrWriter = io.Discard
-	pctx.ParserOptions = append(pctx.ParserOptions, parseOptions...)
-
-	cfg, err := config.ReadStackConfigString(ctx, tgLogger, pctx, filename, text, nil)
+	cfg, err := config.ReadStackConfigString(ctx, s.tgLogger, s.pctx, filename, text, nil)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing stack config", "error", err)
 	}
 
-	filteredDiags := filterHCLDiags(l, parseDiags, filename, text)
+	filteredDiags := filterHCLDiags(l, s.parseDiags, filename, text)
 
 	diags := hclDiagsToLSPDiags(filteredDiags)
 

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -23,11 +23,18 @@ const defaultMaxFoldersToCheck = 100
 // parsingSetup holds the shared state for parsing terragrunt config files.
 type parsingSetup struct {
 	pctx       *config.ParsingContext
-	tgLogger   tgLog.Logger
 	parseDiags hcl.Diagnostics
 }
 
-func newParsingSetup(ctx context.Context, l logger.Logger, filename string) (context.Context, *parsingSetup) {
+func newTGLogger(l logger.Logger) tgLog.Logger {
+	return tgLog.New(
+		tgLog.WithOutput(l.Writer()),
+		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
+		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
+	)
+}
+
+func newParsingSetup(ctx context.Context, tgLogger tgLog.Logger, filename string) (context.Context, *parsingSetup) {
 	s := &parsingSetup{}
 
 	parseOptions := []hclparse.Option{
@@ -37,13 +44,7 @@ func newParsingSetup(ctx context.Context, l logger.Logger, filename string) (con
 		}),
 	}
 
-	s.tgLogger = tgLog.New(
-		tgLog.WithOutput(l.Writer()),
-		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
-		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
-	)
-
-	ctx, s.pctx = config.NewParsingContext(ctx, s.tgLogger)
+	ctx, s.pctx = config.NewParsingContext(ctx, tgLogger)
 	s.pctx.TerragruntConfigPath = filename
 	s.pctx.WorkingDir = filepath.Dir(filename)
 	s.pctx.SkipOutput = true
@@ -56,9 +57,10 @@ func newParsingSetup(ctx context.Context, l logger.Logger, filename string) (con
 }
 
 func ParseTerragruntBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.TerragruntConfig, []protocol.Diagnostic) {
-	ctx, s := newParsingSetup(ctx, l, filename)
+	tgLogger := newTGLogger(l)
+	ctx, s := newParsingSetup(ctx, tgLogger, filename)
 
-	cfg, err := config.ParseConfigString(ctx, s.pctx, s.tgLogger, filename, text, nil)
+	cfg, err := config.ParseConfigString(ctx, s.pctx, tgLogger, filename, text, nil)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing Terragrunt config", "error", err)
@@ -261,9 +263,10 @@ func DetectFileType(filename string) store.FileType {
 
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
 func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
-	ctx, s := newParsingSetup(ctx, l, filename)
+	tgLogger := newTGLogger(l)
+	ctx, s := newParsingSetup(ctx, tgLogger, filename)
 
-	cfg, err := config.ReadStackConfigString(ctx, s.tgLogger, s.pctx, filename, text, nil)
+	cfg, err := config.ReadStackConfigString(ctx, tgLogger, s.pctx, filename, text, nil)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing stack config", "error", err)

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -20,12 +20,6 @@ import (
 
 const defaultMaxFoldersToCheck = 100
 
-// parsingSetup holds the shared state for parsing terragrunt config files.
-type parsingSetup struct {
-	pctx       *config.ParsingContext
-	parseDiags hcl.Diagnostics
-}
-
 func newTGLogger(l logger.Logger) tgLog.Logger {
 	return tgLog.New(
 		tgLog.WithOutput(l.Writer()),
@@ -34,39 +28,41 @@ func newTGLogger(l logger.Logger) tgLog.Logger {
 	)
 }
 
-func newParsingSetup(ctx context.Context, tgLogger tgLog.Logger, filename string) (context.Context, *parsingSetup) {
-	s := &parsingSetup{}
+// newParsingContext builds a terragrunt ParsingContext for the given file and
+// returns a pointer to the HCL diagnostics slice that the parser will populate.
+func newParsingContext(ctx context.Context, tgLogger tgLog.Logger, filename string) (context.Context, *config.ParsingContext, *hcl.Diagnostics) {
+	parseDiags := &hcl.Diagnostics{}
 
 	parseOptions := []hclparse.Option{
 		hclparse.WithDiagnosticsHandler(func(file *hcl.File, hclDiags hcl.Diagnostics) (hcl.Diagnostics, error) {
-			s.parseDiags = append(s.parseDiags, hclDiags...)
+			*parseDiags = append(*parseDiags, hclDiags...)
 			return hclDiags, nil
 		}),
 	}
 
-	ctx, s.pctx = config.NewParsingContext(ctx, tgLogger)
-	s.pctx.TerragruntConfigPath = filename
-	s.pctx.WorkingDir = filepath.Dir(filename)
-	s.pctx.SkipOutput = true
-	s.pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
-	s.pctx.Writers.Writer = io.Discard
-	s.pctx.Writers.ErrWriter = io.Discard
-	s.pctx.ParserOptions = append(s.pctx.ParserOptions, parseOptions...)
+	ctx, pctx := config.NewParsingContext(ctx, tgLogger)
+	pctx.TerragruntConfigPath = filename
+	pctx.WorkingDir = filepath.Dir(filename)
+	pctx.SkipOutput = true
+	pctx.MaxFoldersToCheck = defaultMaxFoldersToCheck
+	pctx.Writers.Writer = io.Discard
+	pctx.Writers.ErrWriter = io.Discard
+	pctx.ParserOptions = append(pctx.ParserOptions, parseOptions...)
 
-	return ctx, s
+	return ctx, pctx, parseDiags
 }
 
 func ParseTerragruntBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.TerragruntConfig, []protocol.Diagnostic) {
 	tgLogger := newTGLogger(l)
-	ctx, s := newParsingSetup(ctx, tgLogger, filename)
+	ctx, pctx, parseDiags := newParsingContext(ctx, tgLogger, filename)
 
-	cfg, err := config.ParseConfigString(ctx, s.pctx, tgLogger, filename, text, nil)
+	cfg, err := config.ParseConfigString(ctx, pctx, tgLogger, filename, text, nil)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing Terragrunt config", "error", err)
 	}
 
-	filteredDiags := filterHCLDiags(l, s.parseDiags, filename, text)
+	filteredDiags := filterHCLDiags(l, *parseDiags, filename, text)
 
 	diags := hclDiagsToLSPDiags(filteredDiags)
 
@@ -264,15 +260,15 @@ func DetectFileType(filename string) store.FileType {
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
 func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
 	tgLogger := newTGLogger(l)
-	ctx, s := newParsingSetup(ctx, tgLogger, filename)
+	ctx, pctx, parseDiags := newParsingContext(ctx, tgLogger, filename)
 
-	cfg, err := config.ReadStackConfigString(ctx, tgLogger, s.pctx, filename, text, nil)
+	cfg, err := config.ReadStackConfigString(ctx, tgLogger, pctx, filename, text, nil)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing stack config", "error", err)
 	}
 
-	filteredDiags := filterHCLDiags(l, s.parseDiags, filename, text)
+	filteredDiags := filterHCLDiags(l, *parseDiags, filename, text)
 
 	diags := hclDiagsToLSPDiags(filteredDiags)
 

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -183,14 +183,14 @@ func DetectFileType(filename string) store.FileType {
 }
 
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
-func ParseStackBuffer(l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
+func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
 	tgLogger := tgLog.New(
 		tgLog.WithOutput(l.Writer()),
 		tgLog.WithLevel(tgLog.FromLogrusLevel(logrus.Level(l.Level()))),
 		tgLog.WithFormatter(format.NewFormatter(format.NewJSONFormatPlaceholders())),
 	)
 
-	ctx, pctx := config.NewParsingContext(context.TODO(), tgLogger)
+	ctx, pctx := config.NewParsingContext(ctx, tgLogger)
 	pctx.TerragruntConfigPath = filename
 	pctx.WorkingDir = filepath.Dir(filename)
 	pctx.SkipOutput = true

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -90,7 +90,7 @@ stack "service" {
 			name:     "empty stack config",
 			content:  "",
 			wantCfg:  false,
-			wantDiag: true,
+			wantDiag: false,
 		},
 		{
 			name: "unit missing source",

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -6,12 +6,154 @@ import (
 	"path/filepath"
 	"terragrunt-ls/internal/testutils"
 	"terragrunt-ls/internal/tg"
+	"terragrunt-ls/internal/tg/store"
 	"testing"
 
 	"github.com/gruntwork-io/terragrunt/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestDetectFileType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		expected store.FileType
+	}{
+		{
+			name:     "regular terragrunt file",
+			filename: "/some/path/terragrunt.hcl",
+			expected: store.FileTypeTerragrunt,
+		},
+		{
+			name:     "stack file",
+			filename: "/some/path/terragrunt.stack.hcl",
+			expected: store.FileTypeStack,
+		},
+		{
+			name:     "values file",
+			filename: "/some/path/terragrunt.values.hcl",
+			expected: store.FileTypeValues,
+		},
+		{
+			name:     "arbitrary hcl file",
+			filename: "/some/path/other.hcl",
+			expected: store.FileTypeTerragrunt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := tg.DetectFileType(tt.filename)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseStackBuffer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		wantCfg  bool
+		wantDiag bool
+	}{
+		{
+			name: "valid stack config with unit",
+			content: `unit "vpc" {
+	source = "./units/vpc"
+	path   = "vpc"
+}`,
+			wantCfg:  true,
+			wantDiag: false,
+		},
+		{
+			name: "valid stack config with stack and unit",
+			content: `unit "vpc" {
+	source = "./units/vpc"
+	path   = "vpc"
+}
+
+stack "service" {
+	source = "./stacks/service"
+	path   = "service"
+}`,
+			wantCfg:  true,
+			wantDiag: false,
+		},
+		{
+			name:     "empty stack config",
+			content:  "",
+			wantCfg:  false,
+			wantDiag: true,
+		},
+		{
+			name: "unit missing source",
+			content: `unit "vpc" {
+	path = "vpc"
+}`,
+			wantCfg:  false,
+			wantDiag: true,
+		},
+		{
+			name: "unit missing path",
+			content: `unit "vpc" {
+	source = "./units/vpc"
+}`,
+			wantCfg:  false,
+			wantDiag: true,
+		},
+		{
+			name:     "unit missing both source and path",
+			content:  `unit "vpc" {}`,
+			wantCfg:  false,
+			wantDiag: true,
+		},
+		{
+			name: "stack missing source",
+			content: `stack "service" {
+	path = "service"
+}`,
+			wantCfg:  false,
+			wantDiag: true,
+		},
+		{
+			name: "stack missing path",
+			content: `stack "service" {
+	source = "./stacks/service"
+}`,
+			wantCfg:  false,
+			wantDiag: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			filename := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+
+			l := testutils.NewTestLogger(t)
+			cfg, diags := tg.ParseStackBuffer(l, filename, tt.content)
+
+			if tt.wantDiag {
+				assert.NotEmpty(t, diags, "expected diagnostics but got none")
+			} else {
+				assert.Empty(t, diags, "expected no diagnostics but got: %v", diags)
+			}
+
+			if tt.wantCfg {
+				assert.NotNil(t, cfg, "expected config to not be nil")
+			}
+		})
+	}
+}
 
 func TestParseTerragruntBuffer(t *testing.T) {
 	t.Parallel()

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -222,6 +222,19 @@ inputs = {
 `,
 			wantDiag: false,
 		},
+		{
+			name: "values attribute access should not show diagnostic",
+			setup: func(t *testing.T, tmpDir string) string {
+				t.Helper()
+
+				return filepath.Join(tmpDir, "terragrunt.hcl")
+			},
+			content: `locals {
+  environment = values.environment
+}
+`,
+			wantDiag: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -140,7 +140,7 @@ stack "service" {
 			filename := filepath.Join(tmpDir, "terragrunt.stack.hcl")
 
 			l := testutils.NewTestLogger(t)
-			cfg, diags := tg.ParseStackBuffer(l, filename, tt.content)
+			cfg, diags := tg.ParseStackBuffer(t.Context(), l, filename, tt.content)
 
 			if tt.wantDiag {
 				assert.NotEmpty(t, diags, "expected diagnostics but got none")

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -25,7 +25,7 @@ func TestDetectFileType(t *testing.T) {
 		{
 			name:     "regular terragrunt file",
 			filename: "/some/path/terragrunt.hcl",
-			expected: store.FileTypeTerragrunt,
+			expected: store.FileTypeUnit,
 		},
 		{
 			name:     "stack file",

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -150,6 +150,8 @@ stack "service" {
 
 			if tt.wantCfg {
 				assert.NotNil(t, cfg, "expected config to not be nil")
+			} else {
+				assert.Nil(t, cfg, "expected config to be nil")
 			}
 		})
 	}

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -40,7 +40,7 @@ func TestDetectFileType(t *testing.T) {
 		{
 			name:     "arbitrary hcl file",
 			filename: "/some/path/other.hcl",
-			expected: store.FileTypeTerragrunt,
+			expected: store.FileTypeUnknown,
 		},
 	}
 

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -89,7 +89,7 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 		diags = unitDiags
 
 	case store.FileTypeStack:
-		stackCfg, stackDiags := ParseStackBuffer(l, filename, text)
+		stackCfg, stackDiags := ParseStackBuffer(ctx, l, filename, text)
 
 		l.Debug(
 			"Stack Config",

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -66,23 +66,7 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 	var diags []protocol.Diagnostic
 
 	switch fileType {
-	case store.FileTypeStack:
-		stackCfg, stackDiags := ParseStackBuffer(l, filename, text)
-
-		l.Debug(
-			"Stack Config",
-			"uri", docURI,
-			"config", stackCfg,
-		)
-
-		st.StackCfg = stackCfg
-		diags = stackDiags
-
-	case store.FileTypeValues:
-		// Values files are generated; only store the document for formatting.
-		diags = []protocol.Diagnostic{}
-
-	default:
+	case store.FileTypeTerragrunt:
 		cfg, unitDiags := ParseTerragruntBuffer(ctx, l, filename, text)
 
 		l.Debug(
@@ -102,6 +86,22 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 		st.Cfg = cfg
 		st.CfgAsCty = cfgAsCty
 		diags = unitDiags
+
+	case store.FileTypeStack:
+		stackCfg, stackDiags := ParseStackBuffer(l, filename, text)
+
+		l.Debug(
+			"Stack Config",
+			"uri", docURI,
+			"config", stackCfg,
+		)
+
+		st.StackCfg = stackCfg
+		diags = stackDiags
+
+	case store.FileTypeValues:
+		// Values files are generated; only store the document for formatting.
+		diags = []protocol.Diagnostic{}
 	}
 
 	s.Configs[filename] = st

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -103,6 +103,9 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 	case store.FileTypeValues:
 		// Values files are generated; only store the document for formatting.
 		diags = []protocol.Diagnostic{}
+
+	case store.FileTypeUnknown:
+		diags = []protocol.Diagnostic{}
 	}
 
 	s.Configs[filename] = st

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -114,7 +114,10 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 }
 
 func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position) lsp.HoverResponse {
-	st := s.Configs[docURI.Filename()]
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok {
+		return newEmptyHoverResponse(id)
+	}
 
 	l.Debug(
 		"Hovering over character",
@@ -193,7 +196,10 @@ func newEmptyHoverResponse(id int) lsp.HoverResponse {
 }
 
 func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position) lsp.DefinitionResponse {
-	st := s.Configs[docURI.Filename()]
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok {
+		return newEmptyDefinitionResponse(id, docURI, position)
+	}
 
 	l.Debug(
 		"Definition requested",
@@ -357,7 +363,15 @@ func newEmptyDefinitionResponse(id int, docURI protocol.DocumentURI, position pr
 }
 
 func (s *State) TextDocumentCompletion(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position) lsp.CompletionResponse {
-	items := completion.GetCompletions(l, s.Configs[docURI.Filename()], position)
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok {
+		return lsp.CompletionResponse{
+			Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+			Result:   []protocol.CompletionItem{},
+		}
+	}
+
+	items := completion.GetCompletions(l, st, position)
 
 	response := lsp.CompletionResponse{
 		Response: lsp.Response{
@@ -371,7 +385,13 @@ func (s *State) TextDocumentCompletion(l logger.Logger, id int, docURI protocol.
 }
 
 func (s *State) TextDocumentFormatting(l logger.Logger, id int, docURI protocol.DocumentURI) lsp.FormatResponse {
-	st := s.Configs[docURI.Filename()]
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok {
+		return lsp.FormatResponse{
+			Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+			Result:   []protocol.TextEdit{},
+		}
+	}
 
 	l.Debug(
 		"Formatting requested",

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -51,31 +51,60 @@ func (s *State) UpdateDocument(ctx context.Context, l logger.Logger, docURI prot
 }
 
 func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protocol.DocumentURI, text string) []protocol.Diagnostic {
+	filename := docURI.Filename()
+	fileType := DetectFileType(filename)
+
 	// Ignore errors from AST indexing since we'll get the same errors from the Terragrunt parser just below
-	ast, _ := ast.ParseHCLFile(docURI.Filename(), []byte(text))
+	indexedAST, _ := ast.ParseHCLFile(filename, []byte(text))
 
-	cfg, diags := ParseTerragruntBuffer(ctx, l, docURI.Filename(), text)
-
-	l.Debug(
-		"Config",
-		"uri", docURI,
-		"config", cfg,
-	)
-
-	cfgAsCty := cty.NilVal
-
-	if cfg != nil {
-		if converted, err := config.TerragruntConfigAsCty(cfg); err == nil {
-			cfgAsCty = converted
-		}
-	}
-
-	s.Configs[docURI.Filename()] = store.Store{
-		AST:      ast,
-		Cfg:      cfg,
-		CfgAsCty: cfgAsCty,
+	st := store.Store{
+		AST:      indexedAST,
 		Document: text,
+		FileType: fileType,
 	}
+
+	var diags []protocol.Diagnostic
+
+	switch fileType {
+	case store.FileTypeStack:
+		stackCfg, stackDiags := ParseStackBuffer(l, filename, text)
+
+		l.Debug(
+			"Stack Config",
+			"uri", docURI,
+			"config", stackCfg,
+		)
+
+		st.StackCfg = stackCfg
+		diags = stackDiags
+
+	case store.FileTypeValues:
+		// Values files are generated; only store the document for formatting.
+		diags = []protocol.Diagnostic{}
+
+	default:
+		cfg, unitDiags := ParseTerragruntBuffer(ctx, l, filename, text)
+
+		l.Debug(
+			"Config",
+			"uri", docURI,
+			"config", cfg,
+		)
+
+		cfgAsCty := cty.NilVal
+
+		if cfg != nil {
+			if converted, err := config.TerragruntConfigAsCty(cfg); err == nil {
+				cfgAsCty = converted
+			}
+		}
+
+		st.Cfg = cfg
+		st.CfgAsCty = cfgAsCty
+		diags = unitDiags
+	}
+
+	s.Configs[filename] = st
 
 	return diags
 }

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -59,6 +59,7 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 
 	st := store.Store{
 		AST:      indexedAST,
+		CfgAsCty: cty.NilVal,
 		Document: text,
 		FileType: fileType,
 	}
@@ -110,7 +111,7 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 }
 
 func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position) lsp.HoverResponse {
-	store := s.Configs[docURI.Filename()]
+	st := s.Configs[docURI.Filename()]
 
 	l.Debug(
 		"Hovering over character",
@@ -118,13 +119,17 @@ func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, posi
 		"position", position,
 	)
 
+	if st.FileType != store.FileTypeTerragrunt {
+		return newEmptyHoverResponse(id)
+	}
+
 	l.Debug(
 		"Config",
 		"uri", docURI,
-		"config", store.Cfg,
+		"config", st.Cfg,
 	)
 
-	word, context := hover.GetHoverTargetWithContext(l, store, position)
+	word, context := hover.GetHoverTargetWithContext(l, st, position)
 
 	l.Debug(
 		"Hovering with context",
@@ -139,19 +144,19 @@ func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, posi
 	//nolint:gocritic
 	switch context {
 	case hover.HoverContextLocal:
-		if store.Cfg == nil {
+		if st.Cfg == nil {
 			return newEmptyHoverResponse(id)
 		}
 
-		if _, ok := store.Cfg.Locals[word]; !ok {
+		if _, ok := st.Cfg.Locals[word]; !ok {
 			return newEmptyHoverResponse(id)
 		}
 
-		if store.CfgAsCty.IsNull() {
+		if st.CfgAsCty.IsNull() {
 			return newEmptyHoverResponse(id)
 		}
 
-		locals := store.CfgAsCty.GetAttr("locals")
+		locals := st.CfgAsCty.GetAttr("locals")
 		localVal := locals.GetAttr(word)
 
 		f := hclwrite.NewEmptyFile()
@@ -185,7 +190,7 @@ func newEmptyHoverResponse(id int) lsp.HoverResponse {
 }
 
 func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position) lsp.DefinitionResponse {
-	store := s.Configs[docURI.Filename()]
+	st := s.Configs[docURI.Filename()]
 
 	l.Debug(
 		"Definition requested",
@@ -193,7 +198,11 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 		"position", position,
 	)
 
-	target, context := definition.GetDefinitionTargetWithContext(l, store, position)
+	if st.FileType != store.FileTypeTerragrunt {
+		return newEmptyDefinitionResponse(id, docURI, position)
+	}
+
+	target, context := definition.GetDefinitionTargetWithContext(l, st, position)
 
 	l.Debug(
 		"Definition discovered",
@@ -210,19 +219,19 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 	case definition.DefinitionContextInclude:
 		l.Debug(
 			"Store content",
-			"store", store,
+			"store", st,
 		)
 
-		if store.Cfg == nil {
+		if st.Cfg == nil {
 			return newEmptyDefinitionResponse(id, docURI, position)
 		}
 
 		l.Debug(
 			"Includes",
-			"includes", store.Cfg.ProcessedIncludes,
+			"includes", st.Cfg.ProcessedIncludes,
 		)
 
-		for _, include := range store.Cfg.ProcessedIncludes {
+		for _, include := range st.Cfg.ProcessedIncludes {
 			if include.Name == target {
 				l.Debug(
 					"Jumping to target",
@@ -260,19 +269,19 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 	case definition.DefinitionContextDependency:
 		l.Debug(
 			"Store content",
-			"store", store,
+			"store", st,
 		)
 
-		if store.Cfg == nil {
+		if st.Cfg == nil {
 			return newEmptyDefinitionResponse(id, docURI, position)
 		}
 
 		l.Debug(
 			"Dependencies",
-			"dependencies", store.Cfg.TerragruntDependencies,
+			"dependencies", st.Cfg.TerragruntDependencies,
 		)
 
-		for _, dep := range store.Cfg.TerragruntDependencies {
+		for _, dep := range st.Cfg.TerragruntDependencies {
 			if dep.Name == target {
 				l.Debug(
 					"Jumping to target",
@@ -359,14 +368,14 @@ func (s *State) TextDocumentCompletion(l logger.Logger, id int, docURI protocol.
 }
 
 func (s *State) TextDocumentFormatting(l logger.Logger, id int, docURI protocol.DocumentURI) lsp.FormatResponse {
-	store := s.Configs[docURI.Filename()]
+	st := s.Configs[docURI.Filename()]
 
 	l.Debug(
 		"Formatting requested",
 		"uri", docURI,
 	)
 
-	formatted := hclwrite.Format([]byte(store.Document))
+	formatted := hclwrite.Format([]byte(st.Document))
 
 	return lsp.FormatResponse{
 		Response: lsp.Response{
@@ -380,7 +389,7 @@ func (s *State) TextDocumentFormatting(l logger.Logger, id int, docURI protocol.
 						Line:      0,
 						Character: 0,
 					},
-					End: getEndOfDocument(store.Document),
+					End: getEndOfDocument(st.Document),
 				},
 				NewText: string(formatted),
 			},

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -67,7 +67,7 @@ func (s *State) updateState(ctx context.Context, l logger.Logger, docURI protoco
 	var diags []protocol.Diagnostic
 
 	switch fileType {
-	case store.FileTypeTerragrunt:
+	case store.FileTypeUnit:
 		cfg, unitDiags := ParseTerragruntBuffer(ctx, l, filename, text)
 
 		l.Debug(
@@ -125,7 +125,7 @@ func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, posi
 		"position", position,
 	)
 
-	if st.FileType != store.FileTypeTerragrunt {
+	if st.FileType != store.FileTypeUnit {
 		return newEmptyHoverResponse(id)
 	}
 
@@ -207,7 +207,7 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 		"position", position,
 	)
 
-	if st.FileType != store.FileTypeTerragrunt {
+	if st.FileType != store.FileTypeUnit {
 		return newEmptyDefinitionResponse(id, docURI, position)
 	}
 

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -1,7 +1,6 @@
 package tg_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,7 +118,7 @@ func TestState_OpenDocument(t *testing.T) {
 
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, unitURI, tt.document)
+			diags := state.OpenDocument(t.Context(), l, unitURI, tt.document)
 			require.Empty(t, diags)
 
 			assert.Len(t, state.Configs, 1)
@@ -196,7 +195,7 @@ func TestState_UpdateDocument(t *testing.T) {
 
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, "file:///foo/terragrunt.hcl", tt.document)
+			diags := state.OpenDocument(t.Context(), l, "file:///foo/terragrunt.hcl", tt.document)
 			assert.Empty(t, diags)
 
 			require.Len(t, state.Configs, 1)
@@ -205,7 +204,7 @@ func TestState_UpdateDocument(t *testing.T) {
 				assert.Equal(t, tt.expected, state.Configs["/foo/terragrunt.hcl"].Cfg.Locals)
 			}
 
-			diags = state.UpdateDocument(context.Background(), l, "file:///foo/terragrunt.hcl", tt.updated)
+			diags = state.UpdateDocument(t.Context(), l, "file:///foo/terragrunt.hcl", tt.updated)
 			assert.Empty(t, diags)
 
 			assert.Len(t, state.Configs, 1)
@@ -283,7 +282,7 @@ func TestState_Hover(t *testing.T) {
 
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, "file:///foo/terragrunt.hcl", tt.document)
+			diags := state.OpenDocument(t.Context(), l, "file:///foo/terragrunt.hcl", tt.document)
 			assert.Empty(t, diags)
 
 			require.Len(t, state.Configs, 1)
@@ -429,7 +428,7 @@ func TestState_Definition(t *testing.T) {
 
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, unitURI, tt.document)
+			diags := state.OpenDocument(t.Context(), l, unitURI, tt.document)
 			assert.Empty(t, diags)
 
 			require.Len(t, state.Configs, 1)
@@ -513,7 +512,7 @@ func TestState_TextDocumentCompletion(t *testing.T) {
 			state := tg.NewState()
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, "file:///terragrunt.hcl", tt.document)
+			diags := state.OpenDocument(t.Context(), l, "file:///terragrunt.hcl", tt.document)
 			if tt.expectDiagnostics {
 				require.NotEmpty(t, diags)
 			} else {
@@ -537,7 +536,7 @@ func TestState_TextDocumentCompletion_StackFile(t *testing.T) {
 	l := testutils.NewTestLogger(t)
 
 	// "uni" is incomplete HCL, so the stack parser will produce diagnostics — that's expected.
-	diags := state.OpenDocument(context.Background(), l, stackURI, "uni")
+	diags := state.OpenDocument(t.Context(), l, stackURI, "uni")
 	require.NotEmpty(t, diags)
 
 	completion := state.TextDocumentCompletion(l, 1, stackURI, protocol.Position{Line: 0, Character: 3})
@@ -556,7 +555,7 @@ func TestState_TextDocumentCompletion_ValuesFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	diags := state.OpenDocument(context.Background(), l, valuesURI, "loc")
+	diags := state.OpenDocument(t.Context(), l, valuesURI, "loc")
 	assert.Empty(t, diags)
 
 	completion := state.TextDocumentCompletion(l, 1, valuesURI, protocol.Position{Line: 0, Character: 3})
@@ -574,7 +573,7 @@ func TestState_OpenDocument_StackFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	diags := state.OpenDocument(context.Background(), l, stackURI, `unit "vpc" {
+	diags := state.OpenDocument(t.Context(), l, stackURI, `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
 }`)
@@ -599,7 +598,7 @@ func TestState_OpenDocument_ValuesFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	diags := state.OpenDocument(context.Background(), l, valuesURI, `some_var = "hello"`)
+	diags := state.OpenDocument(t.Context(), l, valuesURI, `some_var = "hello"`)
 	assert.Empty(t, diags)
 
 	require.Len(t, state.Configs, 1)
@@ -619,7 +618,7 @@ func TestState_Hover_StackFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(context.Background(), l, stackURI, `unit "vpc" {
+	_ = state.OpenDocument(t.Context(), l, stackURI, `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
 }`)
@@ -638,7 +637,7 @@ func TestState_Hover_ValuesFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(context.Background(), l, valuesURI, `some_var = "hello"`)
+	_ = state.OpenDocument(t.Context(), l, valuesURI, `some_var = "hello"`)
 
 	hover := state.Hover(l, 1, valuesURI, protocol.Position{Line: 0, Character: 0})
 	assert.Empty(t, hover.Result.Contents.Value)
@@ -654,7 +653,7 @@ func TestState_Definition_StackFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(context.Background(), l, stackURI, `unit "vpc" {
+	_ = state.OpenDocument(t.Context(), l, stackURI, `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
 }`)
@@ -710,7 +709,7 @@ bar=   "baz"
 			l := testutils.NewTestLogger(t)
 
 			// First open the document to populate the state
-			diags := state.OpenDocument(context.Background(), l, "file:///terragrunt.hcl", tt.document)
+			diags := state.OpenDocument(t.Context(), l, "file:///terragrunt.hcl", tt.document)
 			require.Empty(t, diags)
 
 			// Request formatting

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -537,7 +537,7 @@ func TestState_TextDocumentCompletion_StackFile(t *testing.T) {
 	l := testutils.NewTestLogger(t)
 
 	// "uni" is incomplete HCL, so the stack parser will produce diagnostics — that's expected.
-	_ = state.OpenDocument(l, stackURI, "uni")
+	_ = state.OpenDocument(context.Background(), l, stackURI, "uni")
 
 	completion := state.TextDocumentCompletion(l, 1, stackURI, protocol.Position{Line: 0, Character: 3})
 
@@ -555,7 +555,7 @@ func TestState_TextDocumentCompletion_ValuesFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	diags := state.OpenDocument(l, valuesURI, "loc")
+	diags := state.OpenDocument(context.Background(), l, valuesURI, "loc")
 	assert.Empty(t, diags)
 
 	completion := state.TextDocumentCompletion(l, 1, valuesURI, protocol.Position{Line: 0, Character: 3})
@@ -573,7 +573,7 @@ func TestState_OpenDocument_StackFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	diags := state.OpenDocument(l, stackURI, `unit "vpc" {
+	diags := state.OpenDocument(context.Background(), l, stackURI, `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
 }`)
@@ -598,7 +598,7 @@ func TestState_OpenDocument_ValuesFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	diags := state.OpenDocument(l, valuesURI, `some_var = "hello"`)
+	diags := state.OpenDocument(context.Background(), l, valuesURI, `some_var = "hello"`)
 	assert.Empty(t, diags)
 
 	require.Len(t, state.Configs, 1)
@@ -618,7 +618,7 @@ func TestState_Hover_StackFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(l, stackURI, `unit "vpc" {
+	_ = state.OpenDocument(context.Background(), l, stackURI, `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
 }`)
@@ -637,7 +637,7 @@ func TestState_Hover_ValuesFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(l, valuesURI, `some_var = "hello"`)
+	_ = state.OpenDocument(context.Background(), l, valuesURI, `some_var = "hello"`)
 
 	hover := state.Hover(l, 1, valuesURI, protocol.Position{Line: 0, Character: 0})
 	assert.Empty(t, hover.Result.Contents.Value)
@@ -653,7 +653,7 @@ func TestState_Definition_StackFile(t *testing.T) {
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(l, stackURI, `unit "vpc" {
+	_ = state.OpenDocument(context.Background(), l, stackURI, `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
 }`)

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -588,6 +588,82 @@ func TestState_OpenDocument_StackFile(t *testing.T) {
 	assert.Equal(t, "vpc", st.StackCfg.Units[0].Name)
 }
 
+func TestState_OpenDocument_ValuesFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	valuesPath := filepath.Join(tmpDir, "terragrunt.values.hcl")
+	valuesURI := uri.File(valuesPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	diags := state.OpenDocument(l, valuesURI, `some_var = "hello"`)
+	assert.Empty(t, diags)
+
+	require.Len(t, state.Configs, 1)
+
+	st := state.Configs[valuesPath]
+	assert.Nil(t, st.Cfg)
+	assert.Nil(t, st.StackCfg)
+}
+
+func TestState_Hover_StackFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+	stackURI := uri.File(stackPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	_ = state.OpenDocument(l, stackURI, `unit "vpc" {
+	source = "./units/vpc"
+	path   = "vpc"
+}`)
+
+	hover := state.Hover(l, 1, stackURI, protocol.Position{Line: 0, Character: 0})
+	assert.Empty(t, hover.Result.Contents.Value)
+}
+
+func TestState_Hover_ValuesFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	valuesPath := filepath.Join(tmpDir, "terragrunt.values.hcl")
+	valuesURI := uri.File(valuesPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	_ = state.OpenDocument(l, valuesURI, `some_var = "hello"`)
+
+	hover := state.Hover(l, 1, valuesURI, protocol.Position{Line: 0, Character: 0})
+	assert.Empty(t, hover.Result.Contents.Value)
+}
+
+func TestState_Definition_StackFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+	stackURI := uri.File(stackPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	_ = state.OpenDocument(l, stackURI, `unit "vpc" {
+	source = "./units/vpc"
+	path   = "vpc"
+}`)
+
+	pos := protocol.Position{Line: 0, Character: 0}
+	def := state.Definition(l, 1, stackURI, pos)
+	assert.Equal(t, stackURI, def.Result.URI)
+	assert.Equal(t, pos, def.Result.Range.Start)
+}
+
 func TestState_TextDocumentFormatting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -44,7 +44,7 @@ func TestState_OpenDocument(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the URI for the unit file
-	unitPath := filepath.Join(unitDir, "bar.hcl")
+	unitPath := filepath.Join(unitDir, "terragrunt.hcl")
 
 	unitURI := uri.File(unitPath)
 
@@ -196,22 +196,22 @@ func TestState_UpdateDocument(t *testing.T) {
 
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, "file:///foo/bar.hcl", tt.document)
+			diags := state.OpenDocument(context.Background(), l, "file:///foo/terragrunt.hcl", tt.document)
 			assert.Empty(t, diags)
 
 			require.Len(t, state.Configs, 1)
 
 			if len(tt.expected) != 0 {
-				assert.Equal(t, tt.expected, state.Configs["/foo/bar.hcl"].Cfg.Locals)
+				assert.Equal(t, tt.expected, state.Configs["/foo/terragrunt.hcl"].Cfg.Locals)
 			}
 
-			diags = state.UpdateDocument(context.Background(), l, "file:///foo/bar.hcl", tt.updated)
+			diags = state.UpdateDocument(context.Background(), l, "file:///foo/terragrunt.hcl", tt.updated)
 			assert.Empty(t, diags)
 
 			assert.Len(t, state.Configs, 1)
 
 			if len(tt.expectedUpdated) != 0 {
-				assert.Equal(t, tt.expectedUpdated, state.Configs["/foo/bar.hcl"].Cfg.Locals)
+				assert.Equal(t, tt.expectedUpdated, state.Configs["/foo/terragrunt.hcl"].Cfg.Locals)
 			}
 		})
 	}
@@ -283,12 +283,12 @@ func TestState_Hover(t *testing.T) {
 
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, "file:///foo/bar.hcl", tt.document)
+			diags := state.OpenDocument(context.Background(), l, "file:///foo/terragrunt.hcl", tt.document)
 			assert.Empty(t, diags)
 
 			require.Len(t, state.Configs, 1)
 
-			hover := state.Hover(l, 1, "file:///foo/bar.hcl", tt.position)
+			hover := state.Hover(l, 1, "file:///foo/terragrunt.hcl", tt.position)
 			assert.Equal(t, tt.expected, hover)
 		})
 	}
@@ -321,7 +321,7 @@ func TestState_Definition(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the URI for the unit file
-	unitPath := filepath.Join(unitDir, "bar.hcl")
+	unitPath := filepath.Join(unitDir, "terragrunt.hcl")
 
 	unitURI := uri.File(unitPath)
 
@@ -513,14 +513,14 @@ func TestState_TextDocumentCompletion(t *testing.T) {
 			state := tg.NewState()
 			l := testutils.NewTestLogger(t)
 
-			diags := state.OpenDocument(context.Background(), l, "file:///test.hcl", tt.document)
+			diags := state.OpenDocument(context.Background(), l, "file:///terragrunt.hcl", tt.document)
 			if tt.expectDiagnostics {
 				require.NotEmpty(t, diags)
 			} else {
 				require.Empty(t, diags)
 			}
 
-			completion := state.TextDocumentCompletion(l, 1, "file:///test.hcl", tt.position)
+			completion := state.TextDocumentCompletion(l, 1, "file:///terragrunt.hcl", tt.position)
 			assert.Equal(t, tt.expected, completion)
 		})
 	}
@@ -709,11 +709,11 @@ bar=   "baz"
 			l := testutils.NewTestLogger(t)
 
 			// First open the document to populate the state
-			diags := state.OpenDocument(context.Background(), l, "file:///test.hcl", tt.document)
+			diags := state.OpenDocument(context.Background(), l, "file:///terragrunt.hcl", tt.document)
 			require.Empty(t, diags)
 
 			// Request formatting
-			response := state.TextDocumentFormatting(l, 1, "file:///test.hcl")
+			response := state.TextDocumentFormatting(l, 1, "file:///terragrunt.hcl")
 
 			// Verify the formatting result
 			require.Len(t, response.Result, 1)

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -526,6 +526,68 @@ func TestState_TextDocumentCompletion(t *testing.T) {
 	}
 }
 
+func TestState_TextDocumentCompletion_StackFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+	stackURI := uri.File(stackPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	// "uni" is incomplete HCL, so the stack parser will produce diagnostics — that's expected.
+	_ = state.OpenDocument(l, stackURI, "uni")
+
+	completion := state.TextDocumentCompletion(l, 1, stackURI, protocol.Position{Line: 0, Character: 3})
+
+	require.Len(t, completion.Result, 1)
+	assert.Equal(t, "unit", completion.Result[0].Label)
+}
+
+func TestState_TextDocumentCompletion_ValuesFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	valuesPath := filepath.Join(tmpDir, "terragrunt.values.hcl")
+	valuesURI := uri.File(valuesPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	diags := state.OpenDocument(l, valuesURI, "loc")
+	assert.Empty(t, diags)
+
+	completion := state.TextDocumentCompletion(l, 1, valuesURI, protocol.Position{Line: 0, Character: 3})
+
+	assert.Empty(t, completion.Result)
+}
+
+func TestState_OpenDocument_StackFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+	stackURI := uri.File(stackPath)
+
+	state := tg.NewState()
+	l := testutils.NewTestLogger(t)
+
+	diags := state.OpenDocument(l, stackURI, `unit "vpc" {
+	source = "./units/vpc"
+	path   = "vpc"
+}`)
+	assert.Empty(t, diags)
+
+	require.Len(t, state.Configs, 1)
+
+	st := state.Configs[stackPath]
+	assert.NotNil(t, st.StackCfg)
+	assert.Nil(t, st.Cfg)
+	assert.Len(t, st.StackCfg.Units, 1)
+	assert.Equal(t, "vpc", st.StackCfg.Units[0].Name)
+}
+
 func TestState_TextDocumentFormatting(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -537,7 +537,8 @@ func TestState_TextDocumentCompletion_StackFile(t *testing.T) {
 	l := testutils.NewTestLogger(t)
 
 	// "uni" is incomplete HCL, so the stack parser will produce diagnostics — that's expected.
-	_ = state.OpenDocument(context.Background(), l, stackURI, "uni")
+	diags := state.OpenDocument(context.Background(), l, stackURI, "uni")
+	require.NotEmpty(t, diags)
 
 	completion := state.TextDocumentCompletion(l, 1, stackURI, protocol.Position{Line: 0, Character: 3})
 

--- a/internal/tg/store/store.go
+++ b/internal/tg/store/store.go
@@ -10,9 +10,23 @@ import (
 	"terragrunt-ls/internal/ast"
 )
 
+// FileType identifies the kind of Terragrunt configuration file.
+type FileType int
+
+const (
+	// FileTypeTerragrunt is the default file type for terragrunt.hcl files.
+	FileTypeTerragrunt FileType = iota
+	// FileTypeStack is the file type for terragrunt.stack.hcl files.
+	FileTypeStack
+	// FileTypeValues is the file type for terragrunt.values.hcl files.
+	FileTypeValues
+)
+
 type Store struct {
 	AST      *ast.IndexedAST
 	Cfg      *config.TerragruntConfig
+	StackCfg *config.StackConfig
 	CfgAsCty cty.Value
 	Document string
+	FileType FileType
 }

--- a/internal/tg/store/store.go
+++ b/internal/tg/store/store.go
@@ -14,8 +14,10 @@ import (
 type FileType int
 
 const (
+	// FileTypeUnknown is the file type for unrecognized files.
+	FileTypeUnknown FileType = iota
 	// FileTypeTerragrunt is the default file type for terragrunt.hcl files.
-	FileTypeTerragrunt FileType = iota
+	FileTypeTerragrunt
 	// FileTypeStack is the file type for terragrunt.stack.hcl files.
 	FileTypeStack
 	// FileTypeValues is the file type for terragrunt.values.hcl files.

--- a/internal/tg/store/store.go
+++ b/internal/tg/store/store.go
@@ -16,8 +16,8 @@ type FileType int
 const (
 	// FileTypeUnknown is the file type for unrecognized files.
 	FileTypeUnknown FileType = iota
-	// FileTypeTerragrunt is the default file type for terragrunt.hcl files.
-	FileTypeTerragrunt
+	// FileTypeUnit is the default file type for terragrunt.hcl files.
+	FileTypeUnit
 	// FileTypeStack is the file type for terragrunt.stack.hcl files.
 	FileTypeStack
 	// FileTypeValues is the file type for terragrunt.values.hcl files.

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -19,7 +19,9 @@
 		"vscode": "^1.98.0"
 	},
 	"activationEvents": [
-		"workspaceContains:**/terragrunt.hcl"
+		"workspaceContains:**/terragrunt.hcl",
+		"workspaceContains:**/terragrunt.stack.hcl",
+		"workspaceContains:**/terragrunt.values.hcl"
 	],
 	"main": "./out/extension",
 	"contributes": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -57,7 +57,6 @@ export function activate(context: ExtensionContext) {
 		// Register the server for Terragrunt files
 		documentSelector: [
 			{ scheme: 'file', language: 'terragrunt' },
-			{ scheme: 'file', language: 'hcl' },
 		],
 		synchronize: {
 			// Notify the server about file changes to Terragrunt files

--- a/vscode-extension/syntaxes/terragrunt.tmGrammar.json
+++ b/vscode-extension/syntaxes/terragrunt.tmGrammar.json
@@ -139,6 +139,12 @@
 		"attribute": {
 			"patterns": [
 				{
+					"match": "(\\b(?:inputs|values)\\b)\\s*=(?!=)",
+					"captures": {
+						"1": { "name": "entity.name.type.hcl" }
+					}
+				},
+				{
 					"match": "(\\b[a-zA-Z_][a-zA-Z0-9_]*\\b)\\s*=(?!=)",
 					"captures": {
 						"1": { "name": "variable.other.assignment.hcl" }
@@ -149,7 +155,7 @@
 		"object_key": {
 			"patterns": [
 				{
-					"match": "\\b(local|dependency|include|each|var|module)\\b\\s*\\.\\s*([a-zA-Z_][a-zA-Z0-9_]*)",
+					"match": "\\b(local|dependency|include|each|var|module|values)\\b\\s*\\.\\s*([a-zA-Z_][a-zA-Z0-9_]*)",
 					"captures": {
 						"1": { "name": "support.type.hcl" },
 						"2": { "name": "variable.other.member.hcl" }


### PR DESCRIPTION
## Summary

Blocked by https://github.com/gruntwork-io/terragrunt-ls/pull/125

Closes #13

<img width="388" height="187" alt="Screenshot 2026-04-06 at 21 27 36" src="https://github.com/user-attachments/assets/d9659e43-5391-42e7-a531-dcdac5e3e143" />

- Adds file type detection (`DetectFileType`) to distinguish `terragrunt.hcl`, `terragrunt.stack.hcl`, and `terragrunt.values.hcl`
- Routes stack files through `config.ReadStackConfigString` for proper parsing and validation (required `source`/`path` fields, at least one unit/stack block)
- Provides stack-specific completions (`unit`, `stack`, `locals` blocks) for `terragrunt.stack.hcl` files
- Values files get formatting support only (no parsing, no completions)
- Hover and definition silently no-op for stack/values files (planned for a follow-up PR)
- Updates VS Code extension activation events for the new file types

## Test plan

- [x] `DetectFileType` correctly identifies all three file types
- [x] `ParseStackBuffer` validates required fields (source, path) and returns diagnostics
- [x] Stack file completions return unit/stack/locals blocks
- [x] Values file completions return empty list
- [x] Opening a stack file populates `StackCfg` (not `Cfg`)
- [x] All existing tests pass unchanged


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core document-state parsing/routing to handle multiple Terragrunt file types, which could affect diagnostics and language features across all `.hcl` files if file-type detection or storage is incorrect.
> 
> **Overview**
> Adds first-class support for `terragrunt.stack.hcl` and `terragrunt.values.hcl` by introducing file-type detection and storing the detected `FileType` (plus `StackCfg`) in per-document state.
> 
> Routes `terragrunt.stack.hcl` through a dedicated stack parser (`ReadStackConfigString`) and provides stack-specific completions (`unit`, `stack`, `locals`), while treating `terragrunt.values.hcl` as *formatting-only* (no parsing, no completions). Hover/definition are now gated to only run for `FileTypeTerragrunt`.
> 
> Updates the VS Code extension to recognize/activate on the new filenames, adds a `terragrunt` language contribution with basic language configuration + grammar, and adjusts the client selector to include `terragrunt` documents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae9bf17f12123753b2d1026758d626596259b4a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and parse Stack and Values Terragrunt files.
  * Stack files offer snippet-style completions for unit, stack, and locals.
  * VS Code extension activates for Stack and Values files.

* **Bug Fixes / Behavior**
  * Completions, hover, definition, and formatting respect file type; Values/unknown files yield no completions and empty hover/definition.
  * Parsing diagnostics improved to ignore valid runtime-populated values references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->