### PR TITLE
feat: syntax highlighting and automatic language mode in VSCode

### DIFF
--- a/vscode-extension/language-configuration.json
+++ b/vscode-extension/language-configuration.json
@@ -21,7 +21,7 @@
 		["\"", "\""]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^\\s*(resource|data|variable|output|locals|module|terraform|provider|unit|stack|dependency|dependencies|include|remote_state|generate|feature|exclude|errors|engine|catalog)\\b.*\\{\\s*$|^\\s*\\w+\\s*=\\s*\\{\\s*$|^\\s*\\{\\s*$",
+		"increaseIndentPattern": "^\\s*(locals|terraform|unit|stack|dependency|dependencies|include|remote_state|generate|feature|exclude|errors|engine|catalog|retry|ignore|extra_arguments|before_hook|after_hook|error_hook)\\b.*\\{\\s*$|^\\s*\\w+\\s*=\\s*\\{\\s*$|^\\s*\\{\\s*$",
 		"decreaseIndentPattern": "^\\s*\\}"
 	}
 }

--- a/vscode-extension/language-configuration.json
+++ b/vscode-extension/language-configuration.json
@@ -1,0 +1,27 @@
+{
+	"comments": {
+		"lineComment": "#",
+		"blockComment": ["/*", "*/"]
+	},
+	"brackets": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] }
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""]
+	],
+	"indentationRules": {
+		"increaseIndentPattern": "^\\s*(resource|data|variable|output|locals|module|terraform|provider|unit|stack|dependency|dependencies|include|remote_state|generate|feature|exclude|errors|engine|catalog)\\b.*\\{\\s*$|^\\s*\\w+\\s*=\\s*\\{\\s*$|^\\s*\\{\\s*$",
+		"decreaseIndentPattern": "^\\s*\\}"
+	}
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -23,6 +23,16 @@
 	],
 	"main": "./out/extension",
 	"contributes": {
+		"languages": [
+			{
+				"id": "hcl",
+				"filenames": [
+					"terragrunt.hcl",
+					"terragrunt.stack.hcl",
+					"terragrunt.values.hcl"
+				]
+			}
+		],
 		"configuration": {
 			"type": "object",
 			"title": "Example configuration",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -25,12 +25,21 @@
 	"contributes": {
 		"languages": [
 			{
-				"id": "hcl",
+				"id": "terragrunt",
+				"aliases": ["Terragrunt", "terragrunt"],
 				"filenames": [
 					"terragrunt.hcl",
 					"terragrunt.stack.hcl",
 					"terragrunt.values.hcl"
-				]
+				],
+				"configuration": "./language-configuration.json"
+			}
+		],
+		"grammars": [
+			{
+				"language": "terragrunt",
+				"scopeName": "source.hcl.terragrunt",
+				"path": "./syntaxes/terragrunt.tmGrammar.json"
 			}
 		],
 		"configuration": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -55,7 +55,10 @@ export function activate(context: ExtensionContext) {
 	// Options to control the language client
 	const clientOptions: LanguageClientOptions = {
 		// Register the server for Terragrunt files
-		documentSelector: [{ scheme: 'file', language: 'hcl' }],
+		documentSelector: [
+			{ scheme: 'file', language: 'terragrunt' },
+			{ scheme: 'file', language: 'hcl' },
+		],
 		synchronize: {
 			// Notify the server about file changes to Terragrunt files
 			fileEvents: workspace.createFileSystemWatcher('**/*.hcl')

--- a/vscode-extension/syntaxes/terragrunt.tmGrammar.json
+++ b/vscode-extension/syntaxes/terragrunt.tmGrammar.json
@@ -29,7 +29,7 @@
 			"patterns": [
 				{
 					"name": "meta.block.hcl",
-					"begin": "(\\b(?:unit|stack|dependency|dependencies|include|terraform|remote_state|locals|inputs|generate|feature|exclude|errors|engine|catalog)\\b)(?:\\s+(\"[^\"]*\"))?\\s*\\{",
+					"begin": "(\\b(?:unit|stack|dependency|dependencies|include|terraform|remote_state|locals|generate|feature|exclude|errors|engine|catalog|retry|ignore|extra_arguments|before_hook|after_hook|error_hook)\\b)(?:\\s+(\"[^\"]*\"))?\\s*\\{",
 					"beginCaptures": {
 						"1": { "name": "entity.name.type.hcl" },
 						"2": { "name": "string.quoted.double.hcl" }

--- a/vscode-extension/syntaxes/terragrunt.tmGrammar.json
+++ b/vscode-extension/syntaxes/terragrunt.tmGrammar.json
@@ -1,0 +1,161 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Terragrunt",
+	"scopeName": "source.hcl.terragrunt",
+	"patterns": [
+		{ "include": "#comments" },
+		{ "include": "#block" },
+		{ "include": "#expressions" }
+	],
+	"repository": {
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.number-sign.hcl",
+					"match": "#.*$"
+				},
+				{
+					"name": "comment.line.double-slash.hcl",
+					"match": "//.*$"
+				},
+				{
+					"name": "comment.block.hcl",
+					"begin": "/\\*",
+					"end": "\\*/"
+				}
+			]
+		},
+		"block": {
+			"patterns": [
+				{
+					"name": "meta.block.hcl",
+					"begin": "(\\b(?:unit|stack|dependency|dependencies|include|terraform|remote_state|locals|inputs|generate|feature|exclude|errors|engine|catalog)\\b)(?:\\s+(\"[^\"]*\"))?\\s*\\{",
+					"beginCaptures": {
+						"1": { "name": "entity.name.type.hcl" },
+						"2": { "name": "string.quoted.double.hcl" }
+					},
+					"end": "\\}",
+					"patterns": [
+						{ "include": "#comments" },
+						{ "include": "#block" },
+						{ "include": "#expressions" }
+					]
+				},
+				{
+					"name": "meta.block.other.hcl",
+					"begin": "(\\b[a-zA-Z_][a-zA-Z0-9_]*\\b)(?:\\s+(\"[^\"]*\"))?\\s*\\{",
+					"beginCaptures": {
+						"1": { "name": "entity.name.type.hcl" },
+						"2": { "name": "string.quoted.double.hcl" }
+					},
+					"end": "\\}",
+					"patterns": [
+						{ "include": "#comments" },
+						{ "include": "#block" },
+						{ "include": "#expressions" }
+					]
+				}
+			]
+		},
+		"expressions": {
+			"patterns": [
+				{ "include": "#strings" },
+				{ "include": "#heredoc" },
+				{ "include": "#numbers" },
+				{ "include": "#booleans" },
+				{ "include": "#functions" },
+				{ "include": "#attribute" },
+				{ "include": "#object_key" }
+			]
+		},
+		"strings": {
+			"patterns": [
+				{
+					"name": "string.quoted.double.hcl",
+					"begin": "\"",
+					"end": "\"",
+					"patterns": [
+						{
+							"name": "constant.character.escape.hcl",
+							"match": "\\\\[nrt\"\\\\]"
+						},
+						{
+							"name": "meta.interpolation.hcl",
+							"begin": "\\$\\{",
+							"end": "\\}",
+							"beginCaptures": {
+								"0": { "name": "punctuation.section.interpolation.begin.hcl" }
+							},
+							"endCaptures": {
+								"0": { "name": "punctuation.section.interpolation.end.hcl" }
+							},
+							"patterns": [
+								{ "include": "#expressions" }
+							]
+						}
+					]
+				}
+			]
+		},
+		"heredoc": {
+			"patterns": [
+				{
+					"name": "string.unquoted.heredoc.hcl",
+					"begin": "<<-?\\s*(\\w+)\\s*$",
+					"end": "^\\s*\\1\\s*$",
+					"beginCaptures": {
+						"1": { "name": "keyword.control.heredoc.hcl" }
+					}
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"name": "constant.numeric.hcl",
+					"match": "\\b[0-9]+(\\.[0-9]+)?([eE][+-]?[0-9]+)?\\b"
+				}
+			]
+		},
+		"booleans": {
+			"patterns": [
+				{
+					"name": "constant.language.hcl",
+					"match": "\\b(true|false|null)\\b"
+				}
+			]
+		},
+		"functions": {
+			"patterns": [
+				{
+					"name": "meta.function-call.hcl",
+					"match": "(\\b[a-zA-Z_][a-zA-Z0-9_]*\\b)\\s*\\(",
+					"captures": {
+						"1": { "name": "support.function.hcl" }
+					}
+				}
+			]
+		},
+		"attribute": {
+			"patterns": [
+				{
+					"match": "(\\b[a-zA-Z_][a-zA-Z0-9_]*\\b)\\s*=(?!=)",
+					"captures": {
+						"1": { "name": "variable.other.assignment.hcl" }
+					}
+				}
+			]
+		},
+		"object_key": {
+			"patterns": [
+				{
+					"match": "\\b(local|dependency|include|each|var|module)\\b\\s*\\.\\s*([a-zA-Z_][a-zA-Z0-9_]*)",
+					"captures": {
+						"1": { "name": "support.type.hcl" },
+						"2": { "name": "variable.other.member.hcl" }
+					}
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
Fixes #85 

Making the VSCode extension recognize specific Terragrunt files so it can apply the Language Server parsing there.

<img width="557" height="290" alt="Screenshot 2026-04-07 at 10 32 11" src="https://github.com/user-attachments/assets/97e87e6e-5184-42f5-a666-96908f601c8e" />

Language mode is selected automatically.

<img width="370" height="62" alt="Screenshot 2026-04-07 at 10 34 42" src="https://github.com/user-attachments/assets/60e320bd-13f1-4802-afcf-c871ba6fb06e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Terragrunt language support to VS Code extension, including syntax highlighting, intelligent editor behaviors (auto-closing pairs, bracket matching, smart indentation), and language server integration for Terragrunt files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->