### PR TITLE
ci: Add release workflow for VS Code extension publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,26 +9,9 @@ on:
     tags: ['v*']
 
 jobs:
-  create-release:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Create GitHub Release
-        run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   build:
     name: Package (${{ matrix.vsce_target }})
     runs-on: ubuntu-latest
-    needs: create-release
-    if: always() && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
     strategy:
       matrix:
         include:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,14 @@ permissions:
   contents: write
 
 on:
+  workflow_dispatch:
   push:
     tags: ['v*']
 
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -26,6 +28,7 @@ jobs:
     name: Package (${{ matrix.vsce_target }})
     runs-on: ubuntu-latest
     needs: create-release
+    if: always() && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
     strategy:
       matrix:
         include:
@@ -68,6 +71,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
 
       - name: Upload VSIX to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
         run: gh release upload "$GITHUB_REF_NAME" vscode-extension/*.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,6 +86,7 @@ jobs:
     name: Publish to VS Code Marketplace
     runs-on: ubuntu-latest
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    name: Package (${{ matrix.vsce_target }})
+    runs-on: ubuntu-latest
+    needs: create-release
+    strategy:
+      matrix:
+        include:
+          - vsce_target: linux-x64
+            goos: linux
+            goarch: amd64
+          - vsce_target: linux-arm64
+            goos: linux
+            goarch: arm64
+          - vsce_target: darwin-x64
+            goos: darwin
+            goarch: amd64
+          - vsce_target: darwin-arm64
+            goos: darwin
+            goarch: arm64
+          - vsce_target: win32-x64
+            goos: windows
+            goarch: amd64
+          - vsce_target: win32-arm64
+            goos: windows
+            goarch: arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2025.6.8
+
+      - name: Install npm dependencies
+        run: npm ci
+        working-directory: vscode-extension
+
+      - name: Package VSIX
+        run: npx @vscode/vsce package --target ${{ matrix.vsce_target }}
+        working-directory: vscode-extension
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+
+      - name: Upload VSIX to GitHub Release
+        run: gh release upload "$GITHUB_REF_NAME" vscode-extension/*.vsix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload VSIX as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.vsce_target }}
+          path: vscode-extension/*.vsix
+
+  publish-marketplace:
+    name: Publish to VS Code Marketplace
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2025.6.8
+
+      - name: Download all VSIX artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+
+      - name: Publish to Marketplace
+        run: npx @vscode/vsce publish --packagePath $(find . -iname '*.vsix')
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/vscode-extension/scripts/package.sh
+++ b/vscode-extension/scripts/package.sh
@@ -6,4 +6,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 pushd "$SCRIPT_DIR/.." >/dev/null
 
-go build -o out/terragrunt-ls ..
+BINARY_NAME="terragrunt-ls"
+if [ "${GOOS:-}" = "windows" ]; then
+  BINARY_NAME="terragrunt-ls.exe"
+fi
+
+GOOS="${GOOS:-}" GOARCH="${GOARCH:-}" go build -o "out/${BINARY_NAME}" ..


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` triggered on tag push (`v*`)
- Creates a GitHub Release with auto-generated notes
- Cross-compiles the Go LSP binary for 6 platforms (linux/darwin/windows x amd64/arm64)
- Packages platform-specific VSIX files and uploads them to the GitHub Release
- Publishes all VSIXes to VS Code Marketplace

Also updates `vscode-extension/scripts/package.sh` to support cross-compilation via `GOOS`/`GOARCH` env vars.

Related to #94

## Test plan
- [ ] Set up `VSCE_PAT` secret in repo settings
- [ ] Tag a release (`git tag v0.1.0 && git push origin v0.1.0`) and verify the workflow runs
- [ ] Verify GitHub Release is created with 6 VSIX attachments
- [ ] Verify extension is published to VS Code Marketplace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * New release workflow: manual and tag-triggered releases that build platform-specific extension packages for multiple OS/CPU targets.
  * Generated packages are attached to releases and artifacts; releases are automatically published to the VS Code Marketplace.
  * Build script updated to produce Windows-native executable names and respect target OS/architecture settings during packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->