### PR TITLE
fix: discard subprocess stdout/stderr to prevent LSP stream corruption

### DIFF
--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -2,6 +2,7 @@ package tg
 
 import (
 	"context"
+	"io"
 	"path/filepath"
 	"strings"
 
@@ -44,6 +45,8 @@ func ParseTerragruntBuffer(l logger.Logger, filename, text string) (*config.Terr
 
 	opts.SkipOutput = true
 	opts.NonInteractive = true
+	opts.Writer = io.Discard
+	opts.ErrWriter = io.Discard
 
 	tgLogger := tgLog.New(
 		tgLog.WithOutput(l.Writer()),


### PR DESCRIPTION
## Summary
- `TerragruntOptions.Writer` defaults to `os.Stdout`, so `run_cmd` subprocess output (e.g. `ssh-keygen` fingerprints) leaks into the LSP protocol stream
- This corrupts the `Content-Length` headers, causing the language server client to crash with: `Header must provide a Content-Length property`
- Fix: set `opts.Writer` and `opts.ErrWriter` to `io.Discard` so subprocess output is silently discarded

Fixes https://github.com/gruntwork-io/terragrunt-ls/issues/88

The main root cause of the issue was actually fixed by https://github.com/gruntwork-io/terragrunt-ls/pull/92, but when trying the configuration from the issue above, it generated a new error on the extension:

```
❯ Client Terragrunt Language Server: connection to server is erroring. Header
must provide a Content-Length property. {"256
md5":"b3:37:06:8d:56:9b:79:14:07:2b:ab:28:20:92:21:48 ****@gruntwork.io
(ED25519)\n256 MD5:b3:37:06:8d:56:9b:79:14:07:2b:ab:28:20:92:21:48
****@gruntwork.io (ED25519)\nContent-Length: 190"} Shutting down server.
```

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] Open a `.hcl` file containing `run_cmd("ssh-keygen", ...)` in VSCode and verify the language server no longer crashes