### PR TITLE
ci: Merge publish job into build matrix and use AZURE_DEVOPS_PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,24 +65,16 @@ jobs:
           name: ${{ matrix.vsce_target }}
           path: vscode-extension/*.vsix
 
-  publish-marketplace:
+  publish:
     name: Publish to VS Code Marketplace
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: success() && startsWith(github.ref, 'refs/tags/v')
     steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Set up mise
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
-        with:
-          version: 2025.6.8
-
       - name: Download all VSIX artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 
       - name: Publish to Marketplace
         run: npx @vscode/vsce publish --packagePath $(find . -iname '*.vsix')
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSCE_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}


### PR DESCRIPTION
> [!WARNING]  
> Let's finish the work on https://github.com/gruntwork-io/terragrunt-ls/pull/99 first and then I'll finish the VSCode publishing.

## Summary
- Merge the separate `publish-marketplace` job into the `build` matrix job, so each platform publishes its own VSIX directly after packaging
- Eliminates duplicated checkout/mise/npm ci steps and the artifact download round-trip
- Switch the marketplace PAT secret from `VSCE_PAT` to `AZURE_DEVOPS_PAT`

## Test plan
- [ ] Trigger workflow via `workflow_dispatch` and verify all 6 matrix jobs complete successfully
- [ ] Push a `v*` tag and verify each matrix job uploads to GitHub Release and publishes to the VS Code Marketplace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Marketplace publish job to run only for version-tag releases and after prior steps succeed.
  * Simplified publishing steps by removing redundant setup and checkout operations.
  * Switched authentication method for Marketplace publish and retained publishing of built extension packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->