### PR TITLE
ci: Add Terragrunt-style Go binary release workflow

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -1,0 +1,103 @@
+name: Build Go
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }}/${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: darwin
+            arch: amd64
+          - os: darwin
+            arch: arm64
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm64
+          - os: windows
+            arch: amd64
+          - os: windows
+            arch: arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          version: 2025.6.8
+          experimental: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+
+      - name: Go Build Cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}-${{ matrix.os }}-${{ matrix.arch }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      - name: Go Mod Cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+          CGO_ENABLED: "0"
+        run: |
+          OUTPUT="terragrunt-ls_${GOOS}_${GOARCH}"
+          if [[ "${GOOS}" == "windows" ]]; then
+            OUTPUT="${OUTPUT}.exe"
+          fi
+          go build -o "${OUTPUT}" -trimpath -ldflags "-s -w" .
+
+      - name: Verify static linking
+        env:
+          GOOS: ${{ matrix.os }}
+          GOARCH: ${{ matrix.arch }}
+        run: |
+          OUTPUT="terragrunt-ls_${GOOS}_${GOARCH}"
+          if [[ "${GOOS}" == "windows" ]]; then
+            OUTPUT="${OUTPUT}.exe"
+          fi
+
+          FILE_INFO=$(file "$OUTPUT")
+          echo "$FILE_INFO"
+
+          case "$GOOS" in
+            linux)
+              echo "$FILE_INFO" | grep -q "statically linked"
+              echo "Linux binary is statically linked"
+              ;;
+            darwin)
+              echo "$FILE_INFO" | grep -q "Mach-O.*executable"
+              echo "macOS binary is Mach-O executable"
+              ;;
+            windows)
+              echo "$FILE_INFO" | grep -q "PE32.*executable.*Windows"
+              echo "Windows binary is PE32 executable"
+              ;;
+          esac
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: terragrunt-ls_${{ matrix.os }}_${{ matrix.arch }}
+          path: terragrunt-ls_${{ matrix.os }}_${{ matrix.arch }}*

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,165 @@
+name: Release Go
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.1.0)'
+        required: true
+        type: string
+      clobber:
+        description: 'Overwrite existing release assets (--clobber)'
+        required: false
+        type: boolean
+        default: false
+  push:
+    tags: ['v*']
+
+jobs:
+  build:
+    name: Build All Binaries
+    uses: ./.github/workflows/build-go.yml
+    secrets: inherit
+
+  upload-assets:
+    name: Upload Release Assets
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Get version
+        id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            VERSION="$INPUT_TAG"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+
+          if [[ -z "$VERSION" ]]; then
+            echo "ERROR: Could not determine version" >&2
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION"
+
+      - name: Check if release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ! gh release view "$VERSION" > /dev/null 2>&1; then
+            echo "ERROR: Release not found for tag $VERSION" >&2
+            echo "Create a GitHub release for this tag before running the workflow." >&2
+            exit 1
+          fi
+          echo "Found existing release for $VERSION"
+
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: bin/
+          merge-multiple: true
+
+      - name: Verify binaries downloaded
+        run: |
+          echo "Downloaded binaries:"
+          ls -lahrt bin/
+          BINARY_COUNT=$(find bin/ -type f | wc -l)
+          echo "Total binaries: $BINARY_COUNT"
+          if [[ "$BINARY_COUNT" -lt 6 ]]; then
+            echo "ERROR: Expected at least 6 binaries, found $BINARY_COUNT" >&2
+            exit 1
+          fi
+
+      - name: Set execution permissions
+        run: chmod +x bin/terragrunt-ls_darwin_* bin/terragrunt-ls_linux_*
+
+      - name: Create archives
+        run: |
+          cd bin
+          for binary in terragrunt-ls_*; do
+            if [[ "$binary" == *.zip ]] || [[ "$binary" == *.tar.gz ]]; then
+              continue
+            fi
+            zip "${binary}.zip" "$binary"
+            tar -czf "${binary}.tar.gz" "$binary"
+            echo "Created archives for $binary"
+          done
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd bin
+          sha256sum terragrunt-ls_* > SHA256SUMS
+          echo "SHA256SUMS:"
+          cat SHA256SUMS
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          CLOBBER: ${{ github.event_name == 'workflow_dispatch' && inputs.clobber || 'false' }}
+        run: |
+          CLOBBER_FLAG=""
+          if [[ "$CLOBBER" == "true" ]]; then
+            CLOBBER_FLAG="--clobber"
+            echo "Overwrite mode enabled"
+          fi
+
+          echo "Uploading assets to release $VERSION..."
+          cd bin
+          for file in *; do
+            echo "Uploading $file..."
+            gh release upload "$VERSION" "$file" $CLOBBER_FLAG
+          done
+          echo "All assets uploaded"
+
+      - name: Verify assets uploaded
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ASSETS=$(gh release view "$VERSION" --json 'assets' --jq '.assets[].name')
+          echo "Release assets:"
+          echo "$ASSETS"
+
+          EXPECTED_FILES=(
+            "SHA256SUMS"
+          )
+
+          for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 windows_arm64; do
+            bin="terragrunt-ls_${platform}"
+            if [[ "$platform" == windows_* ]]; then
+              bin="${bin}.exe"
+            fi
+            EXPECTED_FILES+=("$bin" "${bin}.zip" "${bin}.tar.gz")
+          done
+
+          MISSING=0
+          for expected in "${EXPECTED_FILES[@]}"; do
+            if echo "$ASSETS" | grep -q "^${expected}$"; then
+              echo "$expected present"
+            else
+              echo "MISSING: $expected" >&2
+              MISSING=1
+            fi
+          done
+
+          if [[ "$MISSING" -eq 1 ]]; then
+            echo "ERROR: Some expected assets are missing from the release" >&2
+            exit 1
+          fi
+
+          echo "All expected assets verified"

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Generate SHA256SUMS
         run: |
           cd bin
-          sha256sum terragrunt-ls_* > SHA256SUMS
+          sha256sum *.zip *.tar.gz > SHA256SUMS
           echo "SHA256SUMS:"
           cat SHA256SUMS
 
@@ -120,7 +120,7 @@ jobs:
 
           echo "Uploading assets to release $VERSION..."
           cd bin
-          for file in *; do
+          for file in *.zip *.tar.gz SHA256SUMS; do
             echo "Uploading $file..."
             gh release upload "$VERSION" "$file" $CLOBBER_FLAG
           done
@@ -144,7 +144,7 @@ jobs:
             if [[ "$platform" == windows_* ]]; then
               bin="${bin}.exe"
             fi
-            EXPECTED_FILES+=("$bin" "${bin}.zip" "${bin}.tar.gz")
+            EXPECTED_FILES+=("${bin}.zip" "${bin}.tar.gz")
           done
 
           MISSING=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 terragrunt-ls
+dist/
 
 # Put temporary fixtures here.
 tmp-fixtures


### PR DESCRIPTION
## Summary
- Add reusable `build-go.yml` workflow that matrix-builds 6 targets (linux/darwin/windows x amd64/arm64) with static linking verification
- Rewrite `release-go.yml` to call `build-go.yml`, create ZIP/TAR.GZ archives, generate SHA256SUMS, and upload assets to an existing GitHub release

Supports both tag-push (`v*`) and manual `workflow_dispatch` with a clobber option for re-uploading assets.

Closes #98

## Test plan
- [ ] Push a `v*` tag with a pre-created GitHub Release and verify all 6 binaries + archives + SHA256SUMS are uploaded
- [ ] Test `workflow_dispatch` with the `clobber` option to verify asset overwrite works
- [ ] Verify SHA256SUMS contents match the uploaded archives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated build pipeline for Go binaries across macOS, Linux, and Windows (amd64 and arm64 architectures) with dependency caching and binary verification.
  * Added automated release workflow to publish built artifacts to GitHub releases with SHA256 checksums and per-platform archives.
  * Updated repository ignore rules to exclude build output directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->