### PR TITLE
chore: tune Dependabot to monthly with cooldown and PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 3
     cooldown:
-      default: 7
+      default-days: 7
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -19,4 +19,4 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 3
     cooldown:
-      default: 7
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,15 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default: 7
 
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    cooldown:
+      default: 7


### PR DESCRIPTION
## Summary
- Switch Dependabot schedule from weekly to **monthly** for both `github-actions` and `gomod` ecosystems
- Add a **7-day cooldown** between updates
- Cap **open pull requests to 3** per ecosystem

## Test plan
- [ ] Verify Dependabot respects the new monthly schedule on next run
- [ ] Confirm no more than 3 PRs are opened per ecosystem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Dependabot configuration to adjust dependency update frequency and establish limits on concurrent pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->