### PR TITLE
ci: use AZURE_DEVOPS_PAT secret for vsce publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,4 +85,4 @@ jobs:
       - name: Publish to Marketplace
         run: npx @vscode/vsce publish --packagePath $(find . -iname '*.vsix')
         env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          VSCE_PAT: ${{ secrets.AZURE_DEVOPS_PAT }}


### PR DESCRIPTION
## Summary
- The release workflow referenced `secrets.VSCE_PAT`, but the repo only has `AZURE_DEVOPS_PAT` configured, so the env var expanded to empty.
- `vsce publish` reported this as a PAT verification failure (`TF400813`) in the v0.0.1 release run: https://github.com/gruntwork-io/terragrunt-ls/actions/runs/24406291313/job/71444951708
- Switches the workflow to read from the existing `AZURE_DEVOPS_PAT` secret.

## Test plan
- [ ] Re-run the failed `Publish to VS Code Marketplace` job (or push a new tag) and confirm `vsce publish` authenticates and uploads the VSIX bundles.