### PR TITLE
ci: rename vsix displayName to "Terragrunt Language Server (Official)"

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "terragrunt-ls",
-	"displayName": "Terragrunt Language Server",
+	"displayName": "Terragrunt Language Server (Official)",
 	"description": "Official Terragrunt Language Server extension by Gruntwork",
 	"author": "Gruntwork",
 	"license": "MPL-2.0",


### PR DESCRIPTION
## Summary
- The v0.0.2 publish failed with `This extension display name is taken` — `Terragrunt Language Server` is already registered on the Marketplace by `BahramJoharshamshiri.hcl-lsp`.
- Marketplace display names must be globally unique. Disambiguating with `(Official)` so it's clear this is the Gruntwork-published extension.
- Failing run: https://github.com/gruntwork-io/terragrunt-ls/actions/runs/24453138296/job/71447062495

## Test plan
- [ ] After merge + a new `v*` tag, confirm `vsce publish` succeeds without the display-name collision error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension display name to include "(Official)" designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->