### PR TITLE
chore: bump Go to 1.26.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.26"
   issues-exit-code: 1
   tests: true
 output:
@@ -119,6 +119,7 @@ linters:
       - _ci
       - .github
       - .circleci
+      - node_modules
       - third_party$
       - builtin$
       - examples$
@@ -138,6 +139,7 @@ formatters:
       - _ci
       - .github
       - .circleci
+      - node_modules
       - third_party$
       - builtin$
       - examples$

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terragrunt-ls
 
-go 1.24.4
+go 1.26.2
 
 require (
 	github.com/gruntwork-io/terragrunt v0.82.3

--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -145,7 +145,7 @@ func isParentFileNotFoundDiag(diag *hcl.Diagnostic) bool {
 }
 
 func hclDiagsToLSPDiags(hclDiags hcl.Diagnostics) []protocol.Diagnostic {
-	diags := []protocol.Diagnostic{}
+	diags := make([]protocol.Diagnostic, 0, len(hclDiags))
 
 	for _, diag := range hclDiags {
 		diags = append(diags, protocol.Diagnostic{

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.26.2"
-golangci-lint = "2.1.6"
+golangci-lint = "2.11.4"
 lua = "5.4.7"
 node = "23.10.0"
 rust = "1.85.1"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.24.4"
+go = "1.26.2"
 golangci-lint = "2.1.6"
 lua = "5.4.7"
 node = "23.10.0"


### PR DESCRIPTION
## Summary
- Bump Go toolchain from 1.24.4 to 1.26.2 in `go.mod` and `mise.toml`.
- Prepares the repo for a follow-up upgrade to `github.com/gruntwork-io/terragrunt` v1.0.1, which requires Go 1.26. Keeping the toolchain bump isolated so the terragrunt migration PR can focus on API changes (package moves to `pkg/`, `codegen` becoming internal).

## Test plan
- [x] `go build ./...` passes with Go 1.26.2
- [x] `go test ./...` — all packages pass (ast, rpc, tg, completion, definition, hover, text)
- [ ] CI green (mise-action picks up 1.26.2 from `mise.toml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version to 1.26.2 across project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->