### PR TITLE
feat: Add ast/config, ast/stack, stackutils support packages for stack/values features

### DIFF
--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -216,49 +216,6 @@ func TestIsLocalsBlock(t *testing.T) {
 	}
 }
 
-func TestIsIncludeBlock(t *testing.T) {
-	t.Parallel()
-
-	tc := []struct {
-		name     string
-		content  string
-		pos      hcl.Pos
-		expected bool
-	}{
-		{
-			name: "not an include block",
-			content: `inputs = {
-	foo = "bar"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: false,
-		},
-		{
-			name: "include block",
-			content: `include "root" {
-	path = "root.hcl"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
-			require.NoError(t, err)
-
-			require.NotNil(t, indexed)
-
-			node := indexed.FindNodeAt(tt.pos)
-
-			assert.Equal(t, tt.expected, ast.IsIncludeBlock(node))
-		})
-	}
-}
-
 func TestIsAttribute(t *testing.T) {
 	t.Parallel()
 
@@ -302,130 +259,6 @@ func TestIsAttribute(t *testing.T) {
 	}
 }
 
-func TestGetNodeIncludeLabel(t *testing.T) {
-	t.Parallel()
-
-	tc := []struct {
-		name     string
-		content  string
-		expected string
-		pos      hcl.Pos
-	}{
-		{
-			name: "not an include block",
-			content: `inputs = {
-	foo = "bar"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: "",
-		},
-		{
-			name: "include block beginning of path",
-			content: `include "root" {
-	path = "root.hcl"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 2},
-			expected: "root",
-		},
-		{
-			name: "include block end of path",
-			content: `include "root" {
-	path = "root.hcl"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 18},
-			expected: "root",
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
-			require.NoError(t, err)
-
-			require.NotNil(t, indexed)
-
-			node := indexed.FindNodeAt(tt.pos)
-
-			path, ok := ast.GetNodeIncludeLabel(node)
-			if tt.expected == "" {
-				assert.False(t, ok)
-				return
-			}
-
-			assert.True(t, ok)
-			assert.Equal(t, tt.expected, path)
-		})
-	}
-}
-
-func TestGetNodeDependencyLabel(t *testing.T) {
-	t.Parallel()
-
-	tc := []struct {
-		name     string
-		content  string
-		expected string
-		pos      hcl.Pos
-	}{
-		{
-			name: "not a dependency block",
-			content: `inputs = {
-	foo = "bar"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: "",
-		},
-		{
-			name: "dependency block beginning of path",
-			content: `dependency "vpc" {
-	config_path = "../vpc"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 2},
-			expected: "vpc",
-		},
-		{
-			name: "dependency block end of path",
-			content: `dependency "vpc" {
-	config_path = "../vpc"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 18},
-			expected: "vpc",
-		},
-		{
-			name: "dependency block wrong attribute",
-			content: `dependency "vpc" {
-	other_field = "../vpc"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 18},
-			expected: "",
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
-			require.NoError(t, err)
-
-			require.NotNil(t, indexed)
-
-			node := indexed.FindNodeAt(tt.pos)
-
-			path, ok := ast.GetNodeDependencyLabel(node)
-			if tt.expected == "" {
-				assert.False(t, ok)
-				return
-			}
-
-			assert.True(t, ok)
-			assert.Equal(t, tt.expected, path)
-		})
-	}
-}
-
 func TestFindFirstParentMatch(t *testing.T) {
 	t.Parallel()
 
@@ -451,7 +284,7 @@ func TestFindFirstParentMatch(t *testing.T) {
 		foo = "bar"
 	}`,
 			pos:      hcl.Pos{Line: 2, Column: 2},
-			matcher:  ast.IsDependencyBlock,
+			matcher:  func(*ast.IndexedNode) bool { return false },
 			expected: false,
 		},
 	}
@@ -511,7 +344,7 @@ func TestScope_Add(t *testing.T) {
 	})
 }
 
-// Test that include and local scopes are updated in parsing
+// Test that the locals scope is populated during parsing.
 func TestIndexedAST_Scopes(t *testing.T) {
 	t.Parallel()
 
@@ -520,22 +353,12 @@ locals {
   region = "us-west-2"
   env    = "dev"
 }
-
-include "root" {
-  path = find_in_parent_folders()
-}
 `
 	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
 	require.NoError(t, err)
 
-	// Test locals scope
 	locals := indexed.Locals
 	assert.NotNil(t, locals, "Locals scope should not be nil")
 	assert.Contains(t, locals, "region", "Should contain 'region' local")
 	assert.Contains(t, locals, "env", "Should contain 'env' local")
-
-	// Test includes scope existence
-	includes := indexed.Includes
-	assert.NotNil(t, includes, "Includes scope should not be nil")
-	assert.Contains(t, includes, "root", "Should contain 'root' include")
 }

--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -283,8 +283,11 @@ func TestFindFirstParentMatch(t *testing.T) {
 			content: `locals {
 		foo = "bar"
 	}`,
-			pos:      hcl.Pos{Line: 2, Column: 2},
-			matcher:  func(*ast.IndexedNode) bool { return false },
+			pos: hcl.Pos{Line: 2, Column: 2},
+			matcher: func(n *ast.IndexedNode) bool {
+				block, ok := n.Node.(*hclsyntax.Block)
+				return ok && block.Type == "inputs"
+			},
 			expected: false,
 		},
 	}

--- a/internal/ast/config/config.go
+++ b/internal/ast/config/config.go
@@ -1,0 +1,124 @@
+// Package config provides AST functionality specific to standard terragrunt.hcl files.
+package config
+
+import (
+	"terragrunt-ls/internal/ast"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// ConfigAST provides methods for working with standard terragrunt.hcl files.
+type ConfigAST interface {
+	// Core AST methods
+	FindNodeAt(pos hcl.Pos) *ast.IndexedNode
+
+	// Config-specific methods
+	GetIncludeLabel(node *ast.IndexedNode) (string, bool)
+	GetDependencyLabel(node *ast.IndexedNode) (string, bool)
+
+	// Access to scope information
+	GetLocals() ast.Scope
+	GetIncludes() ast.Scope
+}
+
+// configAST is the concrete implementation of ConfigAST
+type configAST struct {
+	*ast.IndexedAST
+	includes ast.Scope
+}
+
+// NewConfigAST creates a new ConfigAST from an IndexedAST
+func NewConfigAST(indexedAST *ast.IndexedAST) ConfigAST {
+	c := &configAST{
+		IndexedAST: indexedAST,
+		includes:   make(ast.Scope),
+	}
+
+	// Build the includes scope by scanning the AST
+	c.buildIncludesScope()
+
+	return c
+}
+
+// buildIncludesScope scans the AST to build the includes scope
+func (c *configAST) buildIncludesScope() {
+	for _, nodes := range c.Index {
+		for _, node := range nodes {
+			if isIncludeBlock(node) {
+				c.includes.Add(node)
+			}
+		}
+	}
+}
+
+// isIncludeBlock returns TRUE if the node is an HCL block of type "include".
+func isIncludeBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "include" && len(block.Labels) > 0
+}
+
+// isDependencyBlock returns TRUE if the node is an HCL block of type "dependency".
+func isDependencyBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "dependency" && len(block.Labels) > 0
+}
+
+// FindNodeAt returns the node at the given position in the file
+func (c *configAST) FindNodeAt(pos hcl.Pos) *ast.IndexedNode {
+	return c.IndexedAST.FindNodeAt(pos)
+}
+
+// GetIncludeLabel returns the label of the given node, if it is an include block
+func (c *configAST) GetIncludeLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	includeBlock := ast.FindFirstParentMatch(attr, isIncludeBlock)
+	if includeBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := includeBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetDependencyLabel returns the label of the given node, if it is a dependency block
+func (c *configAST) GetDependencyLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	if attr.Node.(*hclsyntax.Attribute).Name != "config_path" {
+		return "", false
+	}
+
+	depBlock := ast.FindFirstParentMatch(attr, isDependencyBlock)
+	if depBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := depBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetLocals returns the locals scope
+func (c *configAST) GetLocals() ast.Scope {
+	return c.Locals
+}
+
+// GetIncludes returns the includes scope
+func (c *configAST) GetIncludes() ast.Scope {
+	return c.includes
+}

--- a/internal/ast/config/config.go
+++ b/internal/ast/config/config.go
@@ -81,12 +81,7 @@ func (c *configAST) GetIncludeLabel(node *ast.IndexedNode) (string, bool) {
 		return "", false
 	}
 
-	name := ""
-	if labels := includeBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
-		name = labels[0]
-	}
-
-	return name, true
+	return includeBlock.Node.(*hclsyntax.Block).Labels[0], true
 }
 
 // GetDependencyLabel returns the label of the given node, if it is a dependency block
@@ -105,12 +100,7 @@ func (c *configAST) GetDependencyLabel(node *ast.IndexedNode) (string, bool) {
 		return "", false
 	}
 
-	name := ""
-	if labels := depBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
-		name = labels[0]
-	}
-
-	return name, true
+	return depBlock.Node.(*hclsyntax.Block).Labels[0], true
 }
 
 // GetLocals returns the locals scope

--- a/internal/ast/config/config_test.go
+++ b/internal/ast/config/config_test.go
@@ -1,0 +1,316 @@
+package config_test
+
+import (
+	"terragrunt-ls/internal/ast"
+	"terragrunt-ls/internal/ast/config"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigAST_Interface(t *testing.T) {
+	t.Parallel()
+
+	// Test HCL content with include and dependency blocks
+	content := `
+include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+locals {
+  env = "test"
+}
+`
+
+	// Parse the content
+	indexedAST, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	// Create ConfigAST
+	configAST := config.NewConfigAST(indexedAST)
+	require.NotNil(t, configAST)
+
+	// Test interface methods exist and work
+	assert.NotNil(t, configAST.FindNodeAt)
+	assert.NotNil(t, configAST.GetIncludeLabel)
+	assert.NotNil(t, configAST.GetDependencyLabel)
+	assert.NotNil(t, configAST.GetLocals)
+	assert.NotNil(t, configAST.GetIncludes)
+
+	// Test that locals and includes are captured
+	locals := configAST.GetLocals()
+	assert.NotNil(t, locals)
+
+	includes := configAST.GetIncludes()
+	assert.NotNil(t, includes)
+}
+
+func TestConfigAST_Methods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testFunc func(*testing.T, config.ConfigAST)
+		name     string
+		content  string
+	}{
+		{
+			name: "basic functionality",
+			content: `
+include "root" {
+  path = find_in_parent_folders()
+}
+
+locals {
+  env = "test"
+}
+`,
+			testFunc: func(t *testing.T, configAST config.ConfigAST) {
+				t.Helper()
+				// Basic test - just ensure it doesn't panic
+				assert.NotNil(t, configAST)
+			},
+		},
+		{
+			name: "interface compliance",
+			content: `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`,
+			testFunc: func(t *testing.T, configAST config.ConfigAST) {
+				t.Helper()
+				// Test that it implements the interface
+				var _ = configAST
+				assert.NotNil(t, configAST)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexedAST, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexedAST)
+
+			configAST := config.NewConfigAST(indexedAST)
+			require.NotNil(t, configAST)
+
+			tt.testFunc(t, configAST)
+		})
+	}
+}
+
+func TestConfigAST_GetIncludeLabel(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		content  string
+		expected string
+		pos      hcl.Pos
+	}{
+		{
+			name: "not an include block",
+			content: `inputs = {
+	foo = "bar"
+}`,
+			pos:      hcl.Pos{Line: 1, Column: 1},
+			expected: "",
+		},
+		{
+			name: "include block beginning of path",
+			content: `include "root" {
+	path = "root.hcl"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 2},
+			expected: "root",
+		},
+		{
+			name: "include block end of path",
+			content: `include "root" {
+	path = "root.hcl"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 18},
+			expected: "root",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexed)
+
+			configAST := config.NewConfigAST(indexed)
+			node := configAST.FindNodeAt(tt.pos)
+
+			label, ok := configAST.GetIncludeLabel(node)
+			if tt.expected == "" {
+				assert.False(t, ok)
+				return
+			}
+
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, label)
+		})
+	}
+}
+
+func TestConfigAST_GetDependencyLabel(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		content  string
+		expected string
+		pos      hcl.Pos
+	}{
+		{
+			name: "not a dependency block",
+			content: `inputs = {
+	foo = "bar"
+}`,
+			pos:      hcl.Pos{Line: 1, Column: 1},
+			expected: "",
+		},
+		{
+			name: "dependency block beginning of path",
+			content: `dependency "vpc" {
+	config_path = "../vpc"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 2},
+			expected: "vpc",
+		},
+		{
+			name: "dependency block end of path",
+			content: `dependency "vpc" {
+	config_path = "../vpc"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 18},
+			expected: "vpc",
+		},
+		{
+			name: "dependency block wrong attribute",
+			content: `dependency "vpc" {
+	other_field = "../vpc"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 18},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexed)
+
+			configAST := config.NewConfigAST(indexed)
+			node := configAST.FindNodeAt(tt.pos)
+
+			label, ok := configAST.GetDependencyLabel(node)
+			if tt.expected == "" {
+				assert.False(t, ok)
+				return
+			}
+
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, label)
+		})
+	}
+}
+
+func TestNewConfigAST(t *testing.T) {
+	t.Parallel()
+
+	content := `
+locals {
+  region = "us-west-2"
+  env    = "dev"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`
+	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+
+	configAST := config.NewConfigAST(indexed)
+	require.NotNil(t, configAST)
+
+	// Test interface methods
+	assert.NotNil(t, configAST.GetLocals)
+	assert.NotNil(t, configAST.GetIncludes)
+
+	// Test that locals and includes are captured
+	locals := configAST.GetLocals()
+	assert.NotNil(t, locals)
+	assert.Contains(t, locals, "region")
+	assert.Contains(t, locals, "env")
+
+	includes := configAST.GetIncludes()
+	assert.NotNil(t, includes)
+	assert.Contains(t, includes, "root", "Should contain 'root' include")
+}
+
+func TestConfigAST_GetIncludeLabel_NotIncludeAttribute(t *testing.T) {
+	t.Parallel()
+
+	content := `
+locals {
+  foo = "bar"
+}
+`
+	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+
+	configAST := config.NewConfigAST(indexed)
+
+	// Find foo attribute (not in include block)
+	fooNode := indexed.FindNodeAt(hcl.Pos{Line: 3, Column: 3})
+	require.NotNil(t, fooNode)
+
+	label, ok := configAST.GetIncludeLabel(fooNode)
+	assert.False(t, ok)
+	assert.Empty(t, label)
+}
+
+func TestConfigAST_GetDependencyLabel_NotConfigPath(t *testing.T) {
+	t.Parallel()
+
+	content := `
+dependency "vpc" {
+  other_attr = "value"
+}
+`
+	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+
+	configAST := config.NewConfigAST(indexed)
+
+	// Find other_attr attribute (not config_path)
+	attrNode := indexed.FindNodeAt(hcl.Pos{Line: 3, Column: 3})
+	require.NotNil(t, attrNode)
+
+	label, ok := configAST.GetDependencyLabel(attrNode)
+	assert.False(t, ok)
+	assert.Empty(t, label)
+}

--- a/internal/ast/config/config_test.go
+++ b/internal/ast/config/config_test.go
@@ -37,13 +37,6 @@ locals {
 	configAST := config.NewConfigAST(indexedAST)
 	require.NotNil(t, configAST)
 
-	// Test interface methods exist and work
-	assert.NotNil(t, configAST.FindNodeAt)
-	assert.NotNil(t, configAST.GetIncludeLabel)
-	assert.NotNil(t, configAST.GetDependencyLabel)
-	assert.NotNil(t, configAST.GetLocals)
-	assert.NotNil(t, configAST.GetIncludes)
-
 	// Test that locals and includes are captured
 	locals := configAST.GetLocals()
 	assert.NotNil(t, locals)
@@ -86,8 +79,6 @@ dependency "vpc" {
 `,
 			testFunc: func(t *testing.T, configAST config.ConfigAST) {
 				t.Helper()
-				// Test that it implements the interface
-				var _ = configAST
 				assert.NotNil(t, configAST)
 			},
 		},

--- a/internal/ast/stack/stack.go
+++ b/internal/ast/stack/stack.go
@@ -1,0 +1,180 @@
+// Package stack provides AST functionality specific to terragrunt.stack.hcl files.
+package stack
+
+import (
+	"terragrunt-ls/internal/ast"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// StackAST provides methods for working with terragrunt.stack.hcl files.
+type StackAST interface {
+	FindNodeAt(pos hcl.Pos) *ast.IndexedNode
+
+	GetUnitLabel(node *ast.IndexedNode) (string, bool)
+	GetStackLabel(node *ast.IndexedNode) (string, bool)
+	GetUnitSource(node *ast.IndexedNode) (string, bool)
+	GetUnitPath(node *ast.IndexedNode) (string, bool)
+	GetStackSource(node *ast.IndexedNode) (string, bool)
+	GetStackPath(node *ast.IndexedNode) (string, bool)
+	FindUnitAt(pos hcl.Pos) (*ast.IndexedNode, bool)
+	FindStackAt(pos hcl.Pos) (*ast.IndexedNode, bool)
+}
+
+// stackAST is the concrete implementation of StackAST
+type stackAST struct {
+	*ast.IndexedAST
+}
+
+// NewStackAST creates a new StackAST from an IndexedAST
+func NewStackAST(indexedAST *ast.IndexedAST) StackAST {
+	return &stackAST{IndexedAST: indexedAST}
+}
+
+// FindNodeAt returns the node at the given position in the file
+func (s *stackAST) FindNodeAt(pos hcl.Pos) *ast.IndexedNode {
+	return s.IndexedAST.FindNodeAt(pos)
+}
+
+// GetUnitLabel returns the label of the given node, if it is a unit block
+func (s *stackAST) GetUnitLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	unitBlock := ast.FindFirstParentMatch(attr, isUnitBlock)
+	if unitBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := unitBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetStackLabel returns the label of the given node, if it is a stack block
+func (s *stackAST) GetStackLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	stackBlock := ast.FindFirstParentMatch(attr, isStackBlock)
+	if stackBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := stackBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetUnitSource returns the source attribute value from a unit block
+func (s *stackAST) GetUnitSource(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isUnitBlock, "source")
+}
+
+// GetUnitPath returns the path attribute value from a unit block
+func (s *stackAST) GetUnitPath(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isUnitBlock, "path")
+}
+
+// GetStackSource returns the source attribute value from a stack block
+func (s *stackAST) GetStackSource(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isStackBlock, "source")
+}
+
+// GetStackPath returns the path attribute value from a stack block
+func (s *stackAST) GetStackPath(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isStackBlock, "path")
+}
+
+// FindUnitAt finds a unit block at the given position
+func (s *stackAST) FindUnitAt(pos hcl.Pos) (*ast.IndexedNode, bool) {
+	node := s.FindNodeAt(pos)
+	if node == nil {
+		return nil, false
+	}
+
+	unitBlock := ast.FindFirstParentMatch(node, isUnitBlock)
+
+	return unitBlock, unitBlock != nil
+}
+
+// FindStackAt finds a stack block at the given position
+func (s *stackAST) FindStackAt(pos hcl.Pos) (*ast.IndexedNode, bool) {
+	node := s.FindNodeAt(pos)
+	if node == nil {
+		return nil, false
+	}
+
+	stackBlock := ast.FindFirstParentMatch(node, isStackBlock)
+
+	return stackBlock, stackBlock != nil
+}
+
+// Helper functions
+
+// isUnitBlock returns TRUE if the node is an HCL block of type "unit"
+func isUnitBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "unit" && len(block.Labels) > 0
+}
+
+// isStackBlock returns TRUE if the node is an HCL block of type "stack"
+func isStackBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "stack" && len(block.Labels) > 0
+}
+
+// getBlockAttribute is a helper to get attribute values from blocks
+func (s *stackAST) getBlockAttribute(node *ast.IndexedNode, blockMatcher func(*ast.IndexedNode) bool, attrName string) (string, bool) {
+	// First, try to find the attribute that contains the current node
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	// Check if the found attribute has the name we're looking for
+	if attrNode, ok := attr.Node.(*hclsyntax.Attribute); ok {
+		if attrNode.Name == attrName {
+			// Verify we're within the correct block type
+			block := ast.FindFirstParentMatch(attr, blockMatcher)
+			if block != nil {
+				// Extract the string value from the attribute expression
+				return s.extractStringValue(attrNode.Expr)
+			}
+		}
+	}
+
+	return "", false
+}
+
+// extractStringValue extracts a string value from various HCL expression types
+func (s *stackAST) extractStringValue(expr hclsyntax.Expression) (string, bool) {
+	switch e := expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		if e.Val.Type().FriendlyName() == "string" {
+			return e.Val.AsString(), true
+		}
+	case *hclsyntax.TemplateExpr:
+		// Handle quoted strings which are parsed as TemplateExpr
+		if len(e.Parts) == 1 {
+			if literal, ok := e.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
+				if literal.Val.Type().FriendlyName() == "string" {
+					return literal.Val.AsString(), true
+				}
+			}
+		}
+	}
+
+	return "", false
+}

--- a/internal/ast/stack/stack.go
+++ b/internal/ast/stack/stack.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // StackAST provides methods for working with terragrunt.stack.hcl files.
@@ -39,42 +40,28 @@ func (s *stackAST) FindNodeAt(pos hcl.Pos) *ast.IndexedNode {
 
 // GetUnitLabel returns the label of the given node, if it is a unit block
 func (s *stackAST) GetUnitLabel(node *ast.IndexedNode) (string, bool) {
-	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
-	if attr == nil {
-		return "", false
-	}
-
-	unitBlock := ast.FindFirstParentMatch(attr, isUnitBlock)
-	if unitBlock == nil {
-		return "", false
-	}
-
-	name := ""
-	if labels := unitBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
-		name = labels[0]
-	}
-
-	return name, true
+	return firstLabelFromContainingBlock(node, isUnitBlock)
 }
 
 // GetStackLabel returns the label of the given node, if it is a stack block
 func (s *stackAST) GetStackLabel(node *ast.IndexedNode) (string, bool) {
+	return firstLabelFromContainingBlock(node, isStackBlock)
+}
+
+// firstLabelFromContainingBlock walks up to the containing attribute and then the
+// nearest block matching blockMatcher, returning that block's first label.
+func firstLabelFromContainingBlock(node *ast.IndexedNode, blockMatcher func(*ast.IndexedNode) bool) (string, bool) {
 	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
 	if attr == nil {
 		return "", false
 	}
 
-	stackBlock := ast.FindFirstParentMatch(attr, isStackBlock)
-	if stackBlock == nil {
+	block := ast.FindFirstParentMatch(attr, blockMatcher)
+	if block == nil {
 		return "", false
 	}
 
-	name := ""
-	if labels := stackBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
-		name = labels[0]
-	}
-
-	return name, true
+	return block.Node.(*hclsyntax.Block).Labels[0], true
 }
 
 // GetUnitSource returns the source attribute value from a unit block
@@ -162,14 +149,14 @@ func (s *stackAST) getBlockAttribute(node *ast.IndexedNode, blockMatcher func(*a
 func (s *stackAST) extractStringValue(expr hclsyntax.Expression) (string, bool) {
 	switch e := expr.(type) {
 	case *hclsyntax.LiteralValueExpr:
-		if e.Val.Type().FriendlyName() == "string" {
+		if e.Val.Type() == cty.String {
 			return e.Val.AsString(), true
 		}
 	case *hclsyntax.TemplateExpr:
 		// Handle quoted strings which are parsed as TemplateExpr
 		if len(e.Parts) == 1 {
 			if literal, ok := e.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
-				if literal.Val.Type().FriendlyName() == "string" {
+				if literal.Val.Type() == cty.String {
 					return literal.Val.AsString(), true
 				}
 			}

--- a/internal/ast/stack/stack.go
+++ b/internal/ast/stack/stack.go
@@ -48,15 +48,11 @@ func (s *stackAST) GetStackLabel(node *ast.IndexedNode) (string, bool) {
 	return firstLabelFromContainingBlock(node, isStackBlock)
 }
 
-// firstLabelFromContainingBlock walks up to the containing attribute and then the
-// nearest block matching blockMatcher, returning that block's first label.
+// firstLabelFromContainingBlock walks up from the given node to the nearest
+// block matching blockMatcher (including the node itself) and returns that
+// block's first label.
 func firstLabelFromContainingBlock(node *ast.IndexedNode, blockMatcher func(*ast.IndexedNode) bool) (string, bool) {
-	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
-	if attr == nil {
-		return "", false
-	}
-
-	block := ast.FindFirstParentMatch(attr, blockMatcher)
+	block := ast.FindFirstParentMatch(node, blockMatcher)
 	if block == nil {
 		return "", false
 	}

--- a/internal/ast/stack/stack_test.go
+++ b/internal/ast/stack/stack_test.go
@@ -1,0 +1,369 @@
+package stack_test
+
+import (
+	"terragrunt-ls/internal/ast"
+	"terragrunt-ls/internal/ast/stack"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackAST_Interface(t *testing.T) {
+	t.Parallel()
+
+	// Test HCL content with unit and stack blocks
+	content := `
+unit "database" {
+  source = "git::git@github.com:acme/infrastructure-catalog.git//units/mysql"
+  path   = "database"
+}
+
+unit "app" {
+  source = "git::git@github.com:acme/infrastructure-catalog.git//units/app"
+  path   = "app"
+}
+
+stack "nested" {
+  source = "./nested-stack"
+  path   = "nested"
+}
+`
+
+	// Parse the content
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	// Create StackAST
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	// Test interface methods exist and work
+	assert.NotNil(t, stackAST.FindNodeAt)
+	assert.NotNil(t, stackAST.GetUnitLabel)
+	assert.NotNil(t, stackAST.GetStackLabel)
+	assert.NotNil(t, stackAST.GetUnitSource)
+	assert.NotNil(t, stackAST.GetUnitPath)
+	assert.NotNil(t, stackAST.FindUnitAt)
+	assert.NotNil(t, stackAST.FindStackAt)
+}
+
+func TestStackAST_Methods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testFunc func(*testing.T, stack.StackAST)
+		name     string
+		content  string
+	}{
+		{
+			name: "basic functionality",
+			content: `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+`,
+			testFunc: func(t *testing.T, stackAST stack.StackAST) {
+				t.Helper()
+				// Basic test - just ensure it doesn't panic
+				assert.NotNil(t, stackAST)
+			},
+		},
+		{
+			name: "interface compliance",
+			content: `
+stack "nested" {
+  source = "./nested"
+  path   = "nested"
+}
+`,
+			testFunc: func(t *testing.T, stackAST stack.StackAST) {
+				t.Helper()
+				// Test that it implements the interface
+				var _ = stackAST
+				assert.NotNil(t, stackAST)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexedAST)
+
+			stackAST := stack.NewStackAST(indexedAST)
+			require.NotNil(t, stackAST)
+
+			tt.testFunc(t, stackAST)
+		})
+	}
+}
+
+func TestStackAST_GetUnitSource(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name       string
+		expected   string
+		line       int
+		col        int
+		shouldFind bool
+	}{
+		{
+			name:       "cursor on source attribute name",
+			line:       3, // line with "source = "./database""
+			col:        3, // position on "source"
+			expected:   "./database",
+			shouldFind: true,
+		},
+		{
+			name:       "cursor on source attribute value",
+			line:       3,  // line with "source = "./database""
+			col:        15, // position within "./database"
+			expected:   "./database",
+			shouldFind: true,
+		},
+		{
+			name:       "cursor on path attribute name",
+			line:       4, // line with "path   = "db""
+			col:        3, // position on "path"
+			expected:   "",
+			shouldFind: false, // We're looking for source, not path
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+			node := stackAST.FindNodeAt(pos)
+			require.NotNil(t, node, "should find node at position")
+
+			source, found := stackAST.GetUnitSource(node)
+
+			if tt.shouldFind {
+				assert.True(t, found, "should find unit source")
+				assert.Equal(t, tt.expected, source)
+			} else {
+				assert.False(t, found, "should not find unit source")
+			}
+		})
+	}
+}
+
+func TestStackAST_GetUnitPath(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name       string
+		expected   string
+		line       int
+		col        int
+		shouldFind bool
+	}{
+		{
+			name:       "cursor on path attribute name",
+			line:       4, // line with "path   = "db""
+			col:        3, // position on "path"
+			expected:   "db",
+			shouldFind: true,
+		},
+		{
+			name:       "cursor on path attribute value",
+			line:       4,  // line with "path   = "db""
+			col:        15, // position within "db"
+			expected:   "db",
+			shouldFind: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+			node := stackAST.FindNodeAt(pos)
+			require.NotNil(t, node, "should find node at position")
+
+			path, found := stackAST.GetUnitPath(node)
+
+			if tt.shouldFind {
+				assert.True(t, found, "should find unit path")
+				assert.Equal(t, tt.expected, path)
+			} else {
+				assert.False(t, found, "should not find unit path")
+			}
+		})
+	}
+}
+
+func TestStackAST_FindUnitAt(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+
+unit "app" {
+  source = "./app"
+  path   = "app"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name       string
+		line       int
+		col        int
+		shouldFind bool
+	}{
+		{
+			name:       "cursor inside first unit block",
+			line:       3, // line with "source = "./database""
+			col:        10,
+			shouldFind: true,
+		},
+		{
+			name:       "cursor inside second unit block",
+			line:       8, // line with "source = "./app""
+			col:        10,
+			shouldFind: true,
+		},
+		{
+			name:       "cursor outside unit blocks",
+			line:       1, // empty line at top
+			col:        1,
+			shouldFind: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+			_, found := stackAST.FindUnitAt(pos)
+			assert.Equal(t, tt.shouldFind, found)
+		})
+	}
+}
+
+func TestStackAST_FindStackAt(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+
+stack "nested" {
+  source = "./nested-stack"
+  path   = "nested"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name        string
+		description string
+		line        int
+		col         int
+		shouldFind  bool
+	}{
+		{
+			name:        "inside unit block",
+			line:        2, // inside unit block
+			col:         3,
+			shouldFind:  false,
+			description: "should not find stack block when inside unit block",
+		},
+		{
+			name:        "stack block name",
+			line:        7, // line with "stack "nested" {"
+			col:         3, // position on "stack"
+			shouldFind:  true,
+			description: "should find stack block at block name",
+		},
+		{
+			name:        "stack source attribute",
+			line:        8,  // line with "source = "./nested-stack""
+			col:         15, // position in "./nested-stack"
+			shouldFind:  true,
+			description: "should find stack block at source attribute",
+		},
+		{
+			name:        "stack path attribute",
+			line:        9,  // line with "path = "nested""
+			col:         10, // position in "nested"
+			shouldFind:  true,
+			description: "should find stack block at path attribute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+
+			stackBlock, found := stackAST.FindStackAt(pos)
+
+			assert.Equal(t, tt.shouldFind, found, tt.description)
+			if tt.shouldFind {
+				assert.NotNil(t, stackBlock, "Stack block should not be nil when found")
+			} else {
+				assert.Nil(t, stackBlock, "Stack block should be nil when not found")
+			}
+		})
+	}
+}

--- a/internal/ast/stack/stack_test.go
+++ b/internal/ast/stack/stack_test.go
@@ -39,15 +39,6 @@ stack "nested" {
 	// Create StackAST
 	stackAST := stack.NewStackAST(indexedAST)
 	require.NotNil(t, stackAST)
-
-	// Test interface methods exist and work
-	assert.NotNil(t, stackAST.FindNodeAt)
-	assert.NotNil(t, stackAST.GetUnitLabel)
-	assert.NotNil(t, stackAST.GetStackLabel)
-	assert.NotNil(t, stackAST.GetUnitSource)
-	assert.NotNil(t, stackAST.GetUnitPath)
-	assert.NotNil(t, stackAST.FindUnitAt)
-	assert.NotNil(t, stackAST.FindStackAt)
 }
 
 func TestStackAST_Methods(t *testing.T) {
@@ -82,8 +73,6 @@ stack "nested" {
 `,
 			testFunc: func(t *testing.T, stackAST stack.StackAST) {
 				t.Helper()
-				// Test that it implements the interface
-				var _ = stackAST
 				assert.NotNil(t, stackAST)
 			},
 		},

--- a/internal/stackutils/stackutils.go
+++ b/internal/stackutils/stackutils.go
@@ -1,0 +1,36 @@
+// Package stackutils provides shared utilities for working with Terragrunt stack configurations.
+package stackutils
+
+import (
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+)
+
+// LookupUnitPath looks up the path for a unit from the parsed StackConfig
+func LookupUnitPath(stackCfg *config.StackConfig, unitName string) (string, bool) {
+	if stackCfg == nil {
+		return "", false
+	}
+
+	for _, unit := range stackCfg.Units {
+		if unit != nil && unit.Name == unitName {
+			return unit.Path, true
+		}
+	}
+
+	return "", false
+}
+
+// LookupStackPath looks up the path for a stack from the parsed StackConfig
+func LookupStackPath(stackCfg *config.StackConfig, stackName string) (string, bool) {
+	if stackCfg == nil {
+		return "", false
+	}
+
+	for _, stack := range stackCfg.Stacks {
+		if stack != nil && stack.Name == stackName {
+			return stack.Path, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/stackutils/stackutils_test.go
+++ b/internal/stackutils/stackutils_test.go
@@ -1,0 +1,135 @@
+package stackutils_test
+
+import (
+	"terragrunt-ls/internal/stackutils"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupUnitPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		stackCfg     *config.StackConfig
+		unitName     string
+		expectedPath string
+		expectedOk   bool
+	}{
+		{
+			name:         "nil config",
+			stackCfg:     nil,
+			unitName:     "database",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "unit found",
+			stackCfg: &config.StackConfig{
+				Units: []*config.Unit{
+					{Name: "database", Path: "db", Source: "./database"},
+					{Name: "app", Path: "app", Source: "./app"},
+				},
+			},
+			unitName:     "database",
+			expectedPath: "db",
+			expectedOk:   true,
+		},
+		{
+			name: "unit not found",
+			stackCfg: &config.StackConfig{
+				Units: []*config.Unit{
+					{Name: "database", Path: "db", Source: "./database"},
+				},
+			},
+			unitName:     "missing",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "empty units",
+			stackCfg: &config.StackConfig{
+				Units: []*config.Unit{},
+			},
+			unitName:     "database",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, ok := stackutils.LookupUnitPath(tt.stackCfg, tt.unitName)
+
+			assert.Equal(t, tt.expectedOk, ok)
+			assert.Equal(t, tt.expectedPath, path)
+		})
+	}
+}
+
+func TestLookupStackPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		stackCfg     *config.StackConfig
+		stackName    string
+		expectedPath string
+		expectedOk   bool
+	}{
+		{
+			name:         "nil config",
+			stackCfg:     nil,
+			stackName:    "nested",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "stack found",
+			stackCfg: &config.StackConfig{
+				Stacks: []*config.Stack{
+					{Name: "nested", Path: "nested", Source: "./nested-stack"},
+					{Name: "other", Path: "other", Source: "./other-stack"},
+				},
+			},
+			stackName:    "nested",
+			expectedPath: "nested",
+			expectedOk:   true,
+		},
+		{
+			name: "stack not found",
+			stackCfg: &config.StackConfig{
+				Stacks: []*config.Stack{
+					{Name: "nested", Path: "nested", Source: "./nested-stack"},
+				},
+			},
+			stackName:    "missing",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "empty stacks",
+			stackCfg: &config.StackConfig{
+				Stacks: []*config.Stack{},
+			},
+			stackName:    "nested",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, ok := stackutils.LookupStackPath(tt.stackCfg, tt.stackName)
+
+			assert.Equal(t, tt.expectedOk, ok)
+			assert.Equal(t, tt.expectedPath, path)
+		})
+	}
+}

--- a/internal/tg/definition/definition.go
+++ b/internal/tg/definition/definition.go
@@ -4,6 +4,7 @@ package definition
 
 import (
 	"terragrunt-ls/internal/ast"
+	astconfig "terragrunt-ls/internal/ast/config"
 	"terragrunt-ls/internal/logger"
 	"terragrunt-ls/internal/tg/store"
 
@@ -30,18 +31,20 @@ func GetDefinitionTargetWithContext(l logger.Logger, store store.Store, position
 		return "", DefinitionContextNull
 	}
 
-	node := store.AST.FindNodeAt(ast.ToHCLPos(position))
+	cfgAST := astconfig.NewConfigAST(store.AST)
+
+	node := cfgAST.FindNodeAt(ast.ToHCLPos(position))
 	if node == nil {
 		l.Debug("No node found at", "line", position.Line, "character", position.Character)
 		return "", DefinitionContextNull
 	}
 
-	if include, ok := ast.GetNodeIncludeLabel(node); ok {
+	if include, ok := cfgAST.GetIncludeLabel(node); ok {
 		l.Debug("Found include", "label", include)
 		return include, DefinitionContextInclude
 	}
 
-	if dep, ok := ast.GetNodeDependencyLabel(node); ok {
+	if dep, ok := cfgAST.GetDependencyLabel(node); ok {
 		l.Debug("Found dependency", "label", dep)
 		return dep, DefinitionContextDependency
 	}


### PR DESCRIPTION
## Summary

Ports foundation packages from #55 onto current `main` (post #89 merge), adapting to `main`'s unified `Store` + `FileType` architecture.

- `internal/ast/config`: `ConfigAST` interface with `GetIncludeLabel`, `GetDependencyLabel`, `GetLocals`, `GetIncludes`.
- `internal/ast/stack`: `StackAST` interface with `FindUnitAt`, `FindStackAt`, and unit/stack source/path getters.
- `internal/stackutils`: `LookupUnitPath` and `LookupStackPath` against a parsed `*config.StackConfig`.
- `internal/ast/ast.go`: include/dependency helpers and the `Includes` scope move out — they're config-file concerns and don't belong on the generic `IndexedAST`. Stack files get their own AST package.
- `internal/tg/definition/definition.go`: now wraps `store.AST` in `astconfig.NewConfigAST` and calls through the new interface.

No user-facing behavior changes; definition/hover on `terragrunt.hcl` files is identical. Follow-up PRs build stack/values hover + definition + completion on top of these packages.

Depends on: none (based on `main` at `df11fce`).
Blocks: follow-up PRs for stack hover/definition, values hover/definition, and completion refactor.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/...` — all green
- [x] `golangci-lint run` — 0 issues
- [ ] No manual LSP testing needed; no behavior change on `terragrunt.hcl`. Stack/values handlers are added in follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal AST handling and removed include-block tracking from the core AST index.
  * Call sites now use the new config-specific AST layer for include/dependency lookups.

* **New Features**
  * Added config and stack AST wrappers that expose block/label resolution and attribute extraction.
  * Added utilities to resolve unit and stack paths from stack configurations.

* **Tests**
  * Added comprehensive unit tests for the new AST wrappers and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->