### PR TITLE
feat: Add values-file completions and createCompletionItem helper

### DIFF
--- a/internal/ast/ast_test.go
+++ b/internal/ast/ast_test.go
@@ -216,49 +216,6 @@ func TestIsLocalsBlock(t *testing.T) {
 	}
 }
 
-func TestIsIncludeBlock(t *testing.T) {
-	t.Parallel()
-
-	tc := []struct {
-		name     string
-		content  string
-		pos      hcl.Pos
-		expected bool
-	}{
-		{
-			name: "not an include block",
-			content: `inputs = {
-	foo = "bar"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: false,
-		},
-		{
-			name: "include block",
-			content: `include "root" {
-	path = "root.hcl"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: true,
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
-			require.NoError(t, err)
-
-			require.NotNil(t, indexed)
-
-			node := indexed.FindNodeAt(tt.pos)
-
-			assert.Equal(t, tt.expected, ast.IsIncludeBlock(node))
-		})
-	}
-}
-
 func TestIsAttribute(t *testing.T) {
 	t.Parallel()
 
@@ -302,130 +259,6 @@ func TestIsAttribute(t *testing.T) {
 	}
 }
 
-func TestGetNodeIncludeLabel(t *testing.T) {
-	t.Parallel()
-
-	tc := []struct {
-		name     string
-		content  string
-		expected string
-		pos      hcl.Pos
-	}{
-		{
-			name: "not an include block",
-			content: `inputs = {
-	foo = "bar"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: "",
-		},
-		{
-			name: "include block beginning of path",
-			content: `include "root" {
-	path = "root.hcl"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 2},
-			expected: "root",
-		},
-		{
-			name: "include block end of path",
-			content: `include "root" {
-	path = "root.hcl"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 18},
-			expected: "root",
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
-			require.NoError(t, err)
-
-			require.NotNil(t, indexed)
-
-			node := indexed.FindNodeAt(tt.pos)
-
-			path, ok := ast.GetNodeIncludeLabel(node)
-			if tt.expected == "" {
-				assert.False(t, ok)
-				return
-			}
-
-			assert.True(t, ok)
-			assert.Equal(t, tt.expected, path)
-		})
-	}
-}
-
-func TestGetNodeDependencyLabel(t *testing.T) {
-	t.Parallel()
-
-	tc := []struct {
-		name     string
-		content  string
-		expected string
-		pos      hcl.Pos
-	}{
-		{
-			name: "not a dependency block",
-			content: `inputs = {
-	foo = "bar"
-}`,
-			pos:      hcl.Pos{Line: 1, Column: 1},
-			expected: "",
-		},
-		{
-			name: "dependency block beginning of path",
-			content: `dependency "vpc" {
-	config_path = "../vpc"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 2},
-			expected: "vpc",
-		},
-		{
-			name: "dependency block end of path",
-			content: `dependency "vpc" {
-	config_path = "../vpc"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 18},
-			expected: "vpc",
-		},
-		{
-			name: "dependency block wrong attribute",
-			content: `dependency "vpc" {
-	other_field = "../vpc"
-}`,
-			pos:      hcl.Pos{Line: 2, Column: 18},
-			expected: "",
-		},
-	}
-
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
-			require.NoError(t, err)
-
-			require.NotNil(t, indexed)
-
-			node := indexed.FindNodeAt(tt.pos)
-
-			path, ok := ast.GetNodeDependencyLabel(node)
-			if tt.expected == "" {
-				assert.False(t, ok)
-				return
-			}
-
-			assert.True(t, ok)
-			assert.Equal(t, tt.expected, path)
-		})
-	}
-}
-
 func TestFindFirstParentMatch(t *testing.T) {
 	t.Parallel()
 
@@ -451,7 +284,7 @@ func TestFindFirstParentMatch(t *testing.T) {
 		foo = "bar"
 	}`,
 			pos:      hcl.Pos{Line: 2, Column: 2},
-			matcher:  ast.IsDependencyBlock,
+			matcher:  func(*ast.IndexedNode) bool { return false },
 			expected: false,
 		},
 	}
@@ -511,7 +344,7 @@ func TestScope_Add(t *testing.T) {
 	})
 }
 
-// Test that include and local scopes are updated in parsing
+// Test that the locals scope is populated during parsing.
 func TestIndexedAST_Scopes(t *testing.T) {
 	t.Parallel()
 
@@ -520,22 +353,12 @@ locals {
   region = "us-west-2"
   env    = "dev"
 }
-
-include "root" {
-  path = find_in_parent_folders()
-}
 `
 	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
 	require.NoError(t, err)
 
-	// Test locals scope
 	locals := indexed.Locals
 	assert.NotNil(t, locals, "Locals scope should not be nil")
 	assert.Contains(t, locals, "region", "Should contain 'region' local")
 	assert.Contains(t, locals, "env", "Should contain 'env' local")
-
-	// Test includes scope existence
-	includes := indexed.Includes
-	assert.NotNil(t, includes, "Includes scope should not be nil")
-	assert.Contains(t, includes, "root", "Should contain 'root' include")
 }

--- a/internal/ast/config/config.go
+++ b/internal/ast/config/config.go
@@ -1,0 +1,124 @@
+// Package config provides AST functionality specific to standard terragrunt.hcl files.
+package config
+
+import (
+	"terragrunt-ls/internal/ast"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// ConfigAST provides methods for working with standard terragrunt.hcl files.
+type ConfigAST interface {
+	// Core AST methods
+	FindNodeAt(pos hcl.Pos) *ast.IndexedNode
+
+	// Config-specific methods
+	GetIncludeLabel(node *ast.IndexedNode) (string, bool)
+	GetDependencyLabel(node *ast.IndexedNode) (string, bool)
+
+	// Access to scope information
+	GetLocals() ast.Scope
+	GetIncludes() ast.Scope
+}
+
+// configAST is the concrete implementation of ConfigAST
+type configAST struct {
+	*ast.IndexedAST
+	includes ast.Scope
+}
+
+// NewConfigAST creates a new ConfigAST from an IndexedAST
+func NewConfigAST(indexedAST *ast.IndexedAST) ConfigAST {
+	c := &configAST{
+		IndexedAST: indexedAST,
+		includes:   make(ast.Scope),
+	}
+
+	// Build the includes scope by scanning the AST
+	c.buildIncludesScope()
+
+	return c
+}
+
+// buildIncludesScope scans the AST to build the includes scope
+func (c *configAST) buildIncludesScope() {
+	for _, nodes := range c.Index {
+		for _, node := range nodes {
+			if isIncludeBlock(node) {
+				c.includes.Add(node)
+			}
+		}
+	}
+}
+
+// isIncludeBlock returns TRUE if the node is an HCL block of type "include".
+func isIncludeBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "include" && len(block.Labels) > 0
+}
+
+// isDependencyBlock returns TRUE if the node is an HCL block of type "dependency".
+func isDependencyBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "dependency" && len(block.Labels) > 0
+}
+
+// FindNodeAt returns the node at the given position in the file
+func (c *configAST) FindNodeAt(pos hcl.Pos) *ast.IndexedNode {
+	return c.IndexedAST.FindNodeAt(pos)
+}
+
+// GetIncludeLabel returns the label of the given node, if it is an include block
+func (c *configAST) GetIncludeLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	includeBlock := ast.FindFirstParentMatch(attr, isIncludeBlock)
+	if includeBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := includeBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetDependencyLabel returns the label of the given node, if it is a dependency block
+func (c *configAST) GetDependencyLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	if attr.Node.(*hclsyntax.Attribute).Name != "config_path" {
+		return "", false
+	}
+
+	depBlock := ast.FindFirstParentMatch(attr, isDependencyBlock)
+	if depBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := depBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetLocals returns the locals scope
+func (c *configAST) GetLocals() ast.Scope {
+	return c.Locals
+}
+
+// GetIncludes returns the includes scope
+func (c *configAST) GetIncludes() ast.Scope {
+	return c.includes
+}

--- a/internal/ast/config/config_test.go
+++ b/internal/ast/config/config_test.go
@@ -1,0 +1,316 @@
+package config_test
+
+import (
+	"terragrunt-ls/internal/ast"
+	"terragrunt-ls/internal/ast/config"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigAST_Interface(t *testing.T) {
+	t.Parallel()
+
+	// Test HCL content with include and dependency blocks
+	content := `
+include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+
+locals {
+  env = "test"
+}
+`
+
+	// Parse the content
+	indexedAST, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	// Create ConfigAST
+	configAST := config.NewConfigAST(indexedAST)
+	require.NotNil(t, configAST)
+
+	// Test interface methods exist and work
+	assert.NotNil(t, configAST.FindNodeAt)
+	assert.NotNil(t, configAST.GetIncludeLabel)
+	assert.NotNil(t, configAST.GetDependencyLabel)
+	assert.NotNil(t, configAST.GetLocals)
+	assert.NotNil(t, configAST.GetIncludes)
+
+	// Test that locals and includes are captured
+	locals := configAST.GetLocals()
+	assert.NotNil(t, locals)
+
+	includes := configAST.GetIncludes()
+	assert.NotNil(t, includes)
+}
+
+func TestConfigAST_Methods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testFunc func(*testing.T, config.ConfigAST)
+		name     string
+		content  string
+	}{
+		{
+			name: "basic functionality",
+			content: `
+include "root" {
+  path = find_in_parent_folders()
+}
+
+locals {
+  env = "test"
+}
+`,
+			testFunc: func(t *testing.T, configAST config.ConfigAST) {
+				t.Helper()
+				// Basic test - just ensure it doesn't panic
+				assert.NotNil(t, configAST)
+			},
+		},
+		{
+			name: "interface compliance",
+			content: `
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`,
+			testFunc: func(t *testing.T, configAST config.ConfigAST) {
+				t.Helper()
+				// Test that it implements the interface
+				var _ = configAST
+				assert.NotNil(t, configAST)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexedAST, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexedAST)
+
+			configAST := config.NewConfigAST(indexedAST)
+			require.NotNil(t, configAST)
+
+			tt.testFunc(t, configAST)
+		})
+	}
+}
+
+func TestConfigAST_GetIncludeLabel(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		content  string
+		expected string
+		pos      hcl.Pos
+	}{
+		{
+			name: "not an include block",
+			content: `inputs = {
+	foo = "bar"
+}`,
+			pos:      hcl.Pos{Line: 1, Column: 1},
+			expected: "",
+		},
+		{
+			name: "include block beginning of path",
+			content: `include "root" {
+	path = "root.hcl"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 2},
+			expected: "root",
+		},
+		{
+			name: "include block end of path",
+			content: `include "root" {
+	path = "root.hcl"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 18},
+			expected: "root",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexed)
+
+			configAST := config.NewConfigAST(indexed)
+			node := configAST.FindNodeAt(tt.pos)
+
+			label, ok := configAST.GetIncludeLabel(node)
+			if tt.expected == "" {
+				assert.False(t, ok)
+				return
+			}
+
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, label)
+		})
+	}
+}
+
+func TestConfigAST_GetDependencyLabel(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		content  string
+		expected string
+		pos      hcl.Pos
+	}{
+		{
+			name: "not a dependency block",
+			content: `inputs = {
+	foo = "bar"
+}`,
+			pos:      hcl.Pos{Line: 1, Column: 1},
+			expected: "",
+		},
+		{
+			name: "dependency block beginning of path",
+			content: `dependency "vpc" {
+	config_path = "../vpc"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 2},
+			expected: "vpc",
+		},
+		{
+			name: "dependency block end of path",
+			content: `dependency "vpc" {
+	config_path = "../vpc"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 18},
+			expected: "vpc",
+		},
+		{
+			name: "dependency block wrong attribute",
+			content: `dependency "vpc" {
+	other_field = "../vpc"
+}`,
+			pos:      hcl.Pos{Line: 2, Column: 18},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexed, err := ast.ParseHCLFile("test.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexed)
+
+			configAST := config.NewConfigAST(indexed)
+			node := configAST.FindNodeAt(tt.pos)
+
+			label, ok := configAST.GetDependencyLabel(node)
+			if tt.expected == "" {
+				assert.False(t, ok)
+				return
+			}
+
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, label)
+		})
+	}
+}
+
+func TestNewConfigAST(t *testing.T) {
+	t.Parallel()
+
+	content := `
+locals {
+  region = "us-west-2"
+  env    = "dev"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}
+
+dependency "vpc" {
+  config_path = "../vpc"
+}
+`
+	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+
+	configAST := config.NewConfigAST(indexed)
+	require.NotNil(t, configAST)
+
+	// Test interface methods
+	assert.NotNil(t, configAST.GetLocals)
+	assert.NotNil(t, configAST.GetIncludes)
+
+	// Test that locals and includes are captured
+	locals := configAST.GetLocals()
+	assert.NotNil(t, locals)
+	assert.Contains(t, locals, "region")
+	assert.Contains(t, locals, "env")
+
+	includes := configAST.GetIncludes()
+	assert.NotNil(t, includes)
+	assert.Contains(t, includes, "root", "Should contain 'root' include")
+}
+
+func TestConfigAST_GetIncludeLabel_NotIncludeAttribute(t *testing.T) {
+	t.Parallel()
+
+	content := `
+locals {
+  foo = "bar"
+}
+`
+	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+
+	configAST := config.NewConfigAST(indexed)
+
+	// Find foo attribute (not in include block)
+	fooNode := indexed.FindNodeAt(hcl.Pos{Line: 3, Column: 3})
+	require.NotNil(t, fooNode)
+
+	label, ok := configAST.GetIncludeLabel(fooNode)
+	assert.False(t, ok)
+	assert.Empty(t, label)
+}
+
+func TestConfigAST_GetDependencyLabel_NotConfigPath(t *testing.T) {
+	t.Parallel()
+
+	content := `
+dependency "vpc" {
+  other_attr = "value"
+}
+`
+	indexed, err := ast.ParseHCLFile("test.hcl", []byte(content))
+	require.NoError(t, err)
+
+	configAST := config.NewConfigAST(indexed)
+
+	// Find other_attr attribute (not config_path)
+	attrNode := indexed.FindNodeAt(hcl.Pos{Line: 3, Column: 3})
+	require.NotNil(t, attrNode)
+
+	label, ok := configAST.GetDependencyLabel(attrNode)
+	assert.False(t, ok)
+	assert.Empty(t, label)
+}

--- a/internal/ast/stack/stack.go
+++ b/internal/ast/stack/stack.go
@@ -1,0 +1,180 @@
+// Package stack provides AST functionality specific to terragrunt.stack.hcl files.
+package stack
+
+import (
+	"terragrunt-ls/internal/ast"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// StackAST provides methods for working with terragrunt.stack.hcl files.
+type StackAST interface {
+	FindNodeAt(pos hcl.Pos) *ast.IndexedNode
+
+	GetUnitLabel(node *ast.IndexedNode) (string, bool)
+	GetStackLabel(node *ast.IndexedNode) (string, bool)
+	GetUnitSource(node *ast.IndexedNode) (string, bool)
+	GetUnitPath(node *ast.IndexedNode) (string, bool)
+	GetStackSource(node *ast.IndexedNode) (string, bool)
+	GetStackPath(node *ast.IndexedNode) (string, bool)
+	FindUnitAt(pos hcl.Pos) (*ast.IndexedNode, bool)
+	FindStackAt(pos hcl.Pos) (*ast.IndexedNode, bool)
+}
+
+// stackAST is the concrete implementation of StackAST
+type stackAST struct {
+	*ast.IndexedAST
+}
+
+// NewStackAST creates a new StackAST from an IndexedAST
+func NewStackAST(indexedAST *ast.IndexedAST) StackAST {
+	return &stackAST{IndexedAST: indexedAST}
+}
+
+// FindNodeAt returns the node at the given position in the file
+func (s *stackAST) FindNodeAt(pos hcl.Pos) *ast.IndexedNode {
+	return s.IndexedAST.FindNodeAt(pos)
+}
+
+// GetUnitLabel returns the label of the given node, if it is a unit block
+func (s *stackAST) GetUnitLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	unitBlock := ast.FindFirstParentMatch(attr, isUnitBlock)
+	if unitBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := unitBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetStackLabel returns the label of the given node, if it is a stack block
+func (s *stackAST) GetStackLabel(node *ast.IndexedNode) (string, bool) {
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	stackBlock := ast.FindFirstParentMatch(attr, isStackBlock)
+	if stackBlock == nil {
+		return "", false
+	}
+
+	name := ""
+	if labels := stackBlock.Node.(*hclsyntax.Block).Labels; len(labels) > 0 {
+		name = labels[0]
+	}
+
+	return name, true
+}
+
+// GetUnitSource returns the source attribute value from a unit block
+func (s *stackAST) GetUnitSource(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isUnitBlock, "source")
+}
+
+// GetUnitPath returns the path attribute value from a unit block
+func (s *stackAST) GetUnitPath(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isUnitBlock, "path")
+}
+
+// GetStackSource returns the source attribute value from a stack block
+func (s *stackAST) GetStackSource(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isStackBlock, "source")
+}
+
+// GetStackPath returns the path attribute value from a stack block
+func (s *stackAST) GetStackPath(node *ast.IndexedNode) (string, bool) {
+	return s.getBlockAttribute(node, isStackBlock, "path")
+}
+
+// FindUnitAt finds a unit block at the given position
+func (s *stackAST) FindUnitAt(pos hcl.Pos) (*ast.IndexedNode, bool) {
+	node := s.FindNodeAt(pos)
+	if node == nil {
+		return nil, false
+	}
+
+	unitBlock := ast.FindFirstParentMatch(node, isUnitBlock)
+
+	return unitBlock, unitBlock != nil
+}
+
+// FindStackAt finds a stack block at the given position
+func (s *stackAST) FindStackAt(pos hcl.Pos) (*ast.IndexedNode, bool) {
+	node := s.FindNodeAt(pos)
+	if node == nil {
+		return nil, false
+	}
+
+	stackBlock := ast.FindFirstParentMatch(node, isStackBlock)
+
+	return stackBlock, stackBlock != nil
+}
+
+// Helper functions
+
+// isUnitBlock returns TRUE if the node is an HCL block of type "unit"
+func isUnitBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "unit" && len(block.Labels) > 0
+}
+
+// isStackBlock returns TRUE if the node is an HCL block of type "stack"
+func isStackBlock(inode *ast.IndexedNode) bool {
+	block, ok := inode.Node.(*hclsyntax.Block)
+	return ok && block.Type == "stack" && len(block.Labels) > 0
+}
+
+// getBlockAttribute is a helper to get attribute values from blocks
+func (s *stackAST) getBlockAttribute(node *ast.IndexedNode, blockMatcher func(*ast.IndexedNode) bool, attrName string) (string, bool) {
+	// First, try to find the attribute that contains the current node
+	attr := ast.FindFirstParentMatch(node, ast.IsAttribute)
+	if attr == nil {
+		return "", false
+	}
+
+	// Check if the found attribute has the name we're looking for
+	if attrNode, ok := attr.Node.(*hclsyntax.Attribute); ok {
+		if attrNode.Name == attrName {
+			// Verify we're within the correct block type
+			block := ast.FindFirstParentMatch(attr, blockMatcher)
+			if block != nil {
+				// Extract the string value from the attribute expression
+				return s.extractStringValue(attrNode.Expr)
+			}
+		}
+	}
+
+	return "", false
+}
+
+// extractStringValue extracts a string value from various HCL expression types
+func (s *stackAST) extractStringValue(expr hclsyntax.Expression) (string, bool) {
+	switch e := expr.(type) {
+	case *hclsyntax.LiteralValueExpr:
+		if e.Val.Type().FriendlyName() == "string" {
+			return e.Val.AsString(), true
+		}
+	case *hclsyntax.TemplateExpr:
+		// Handle quoted strings which are parsed as TemplateExpr
+		if len(e.Parts) == 1 {
+			if literal, ok := e.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
+				if literal.Val.Type().FriendlyName() == "string" {
+					return literal.Val.AsString(), true
+				}
+			}
+		}
+	}
+
+	return "", false
+}

--- a/internal/ast/stack/stack_test.go
+++ b/internal/ast/stack/stack_test.go
@@ -1,0 +1,369 @@
+package stack_test
+
+import (
+	"terragrunt-ls/internal/ast"
+	"terragrunt-ls/internal/ast/stack"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackAST_Interface(t *testing.T) {
+	t.Parallel()
+
+	// Test HCL content with unit and stack blocks
+	content := `
+unit "database" {
+  source = "git::git@github.com:acme/infrastructure-catalog.git//units/mysql"
+  path   = "database"
+}
+
+unit "app" {
+  source = "git::git@github.com:acme/infrastructure-catalog.git//units/app"
+  path   = "app"
+}
+
+stack "nested" {
+  source = "./nested-stack"
+  path   = "nested"
+}
+`
+
+	// Parse the content
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	// Create StackAST
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	// Test interface methods exist and work
+	assert.NotNil(t, stackAST.FindNodeAt)
+	assert.NotNil(t, stackAST.GetUnitLabel)
+	assert.NotNil(t, stackAST.GetStackLabel)
+	assert.NotNil(t, stackAST.GetUnitSource)
+	assert.NotNil(t, stackAST.GetUnitPath)
+	assert.NotNil(t, stackAST.FindUnitAt)
+	assert.NotNil(t, stackAST.FindStackAt)
+}
+
+func TestStackAST_Methods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testFunc func(*testing.T, stack.StackAST)
+		name     string
+		content  string
+	}{
+		{
+			name: "basic functionality",
+			content: `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+`,
+			testFunc: func(t *testing.T, stackAST stack.StackAST) {
+				t.Helper()
+				// Basic test - just ensure it doesn't panic
+				assert.NotNil(t, stackAST)
+			},
+		},
+		{
+			name: "interface compliance",
+			content: `
+stack "nested" {
+  source = "./nested"
+  path   = "nested"
+}
+`,
+			testFunc: func(t *testing.T, stackAST stack.StackAST) {
+				t.Helper()
+				// Test that it implements the interface
+				var _ = stackAST
+				assert.NotNil(t, stackAST)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(tt.content))
+			require.NoError(t, err)
+			require.NotNil(t, indexedAST)
+
+			stackAST := stack.NewStackAST(indexedAST)
+			require.NotNil(t, stackAST)
+
+			tt.testFunc(t, stackAST)
+		})
+	}
+}
+
+func TestStackAST_GetUnitSource(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name       string
+		expected   string
+		line       int
+		col        int
+		shouldFind bool
+	}{
+		{
+			name:       "cursor on source attribute name",
+			line:       3, // line with "source = "./database""
+			col:        3, // position on "source"
+			expected:   "./database",
+			shouldFind: true,
+		},
+		{
+			name:       "cursor on source attribute value",
+			line:       3,  // line with "source = "./database""
+			col:        15, // position within "./database"
+			expected:   "./database",
+			shouldFind: true,
+		},
+		{
+			name:       "cursor on path attribute name",
+			line:       4, // line with "path   = "db""
+			col:        3, // position on "path"
+			expected:   "",
+			shouldFind: false, // We're looking for source, not path
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+			node := stackAST.FindNodeAt(pos)
+			require.NotNil(t, node, "should find node at position")
+
+			source, found := stackAST.GetUnitSource(node)
+
+			if tt.shouldFind {
+				assert.True(t, found, "should find unit source")
+				assert.Equal(t, tt.expected, source)
+			} else {
+				assert.False(t, found, "should not find unit source")
+			}
+		})
+	}
+}
+
+func TestStackAST_GetUnitPath(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name       string
+		expected   string
+		line       int
+		col        int
+		shouldFind bool
+	}{
+		{
+			name:       "cursor on path attribute name",
+			line:       4, // line with "path   = "db""
+			col:        3, // position on "path"
+			expected:   "db",
+			shouldFind: true,
+		},
+		{
+			name:       "cursor on path attribute value",
+			line:       4,  // line with "path   = "db""
+			col:        15, // position within "db"
+			expected:   "db",
+			shouldFind: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+			node := stackAST.FindNodeAt(pos)
+			require.NotNil(t, node, "should find node at position")
+
+			path, found := stackAST.GetUnitPath(node)
+
+			if tt.shouldFind {
+				assert.True(t, found, "should find unit path")
+				assert.Equal(t, tt.expected, path)
+			} else {
+				assert.False(t, found, "should not find unit path")
+			}
+		})
+	}
+}
+
+func TestStackAST_FindUnitAt(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+
+unit "app" {
+  source = "./app"
+  path   = "app"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name       string
+		line       int
+		col        int
+		shouldFind bool
+	}{
+		{
+			name:       "cursor inside first unit block",
+			line:       3, // line with "source = "./database""
+			col:        10,
+			shouldFind: true,
+		},
+		{
+			name:       "cursor inside second unit block",
+			line:       8, // line with "source = "./app""
+			col:        10,
+			shouldFind: true,
+		},
+		{
+			name:       "cursor outside unit blocks",
+			line:       1, // empty line at top
+			col:        1,
+			shouldFind: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+			_, found := stackAST.FindUnitAt(pos)
+			assert.Equal(t, tt.shouldFind, found)
+		})
+	}
+}
+
+func TestStackAST_FindStackAt(t *testing.T) {
+	t.Parallel()
+
+	content := `
+unit "database" {
+  source = "./database"
+  path   = "db"
+}
+
+stack "nested" {
+  source = "./nested-stack"
+  path   = "nested"
+}
+`
+
+	indexedAST, err := ast.ParseHCLFile("test.stack.hcl", []byte(content))
+	require.NoError(t, err)
+	require.NotNil(t, indexedAST)
+
+	stackAST := stack.NewStackAST(indexedAST)
+	require.NotNil(t, stackAST)
+
+	tests := []struct {
+		name        string
+		description string
+		line        int
+		col         int
+		shouldFind  bool
+	}{
+		{
+			name:        "inside unit block",
+			line:        2, // inside unit block
+			col:         3,
+			shouldFind:  false,
+			description: "should not find stack block when inside unit block",
+		},
+		{
+			name:        "stack block name",
+			line:        7, // line with "stack "nested" {"
+			col:         3, // position on "stack"
+			shouldFind:  true,
+			description: "should find stack block at block name",
+		},
+		{
+			name:        "stack source attribute",
+			line:        8,  // line with "source = "./nested-stack""
+			col:         15, // position in "./nested-stack"
+			shouldFind:  true,
+			description: "should find stack block at source attribute",
+		},
+		{
+			name:        "stack path attribute",
+			line:        9,  // line with "path = "nested""
+			col:         10, // position in "nested"
+			shouldFind:  true,
+			description: "should find stack block at path attribute",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pos := hcl.Pos{Line: tt.line, Column: tt.col}
+
+			stackBlock, found := stackAST.FindStackAt(pos)
+
+			assert.Equal(t, tt.shouldFind, found, tt.description)
+			if tt.shouldFind {
+				assert.NotNil(t, stackBlock, "Stack block should not be nil when found")
+			} else {
+				assert.Nil(t, stackBlock, "Stack block should be nil when not found")
+			}
+		})
+	}
+}

--- a/internal/stackutils/stackutils.go
+++ b/internal/stackutils/stackutils.go
@@ -1,0 +1,36 @@
+// Package stackutils provides shared utilities for working with Terragrunt stack configurations.
+package stackutils
+
+import (
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+)
+
+// LookupUnitPath looks up the path for a unit from the parsed StackConfig
+func LookupUnitPath(stackCfg *config.StackConfig, unitName string) (string, bool) {
+	if stackCfg == nil {
+		return "", false
+	}
+
+	for _, unit := range stackCfg.Units {
+		if unit != nil && unit.Name == unitName {
+			return unit.Path, true
+		}
+	}
+
+	return "", false
+}
+
+// LookupStackPath looks up the path for a stack from the parsed StackConfig
+func LookupStackPath(stackCfg *config.StackConfig, stackName string) (string, bool) {
+	if stackCfg == nil {
+		return "", false
+	}
+
+	for _, stack := range stackCfg.Stacks {
+		if stack != nil && stack.Name == stackName {
+			return stack.Path, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/stackutils/stackutils_test.go
+++ b/internal/stackutils/stackutils_test.go
@@ -1,0 +1,135 @@
+package stackutils_test
+
+import (
+	"terragrunt-ls/internal/stackutils"
+	"testing"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupUnitPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		stackCfg     *config.StackConfig
+		unitName     string
+		expectedPath string
+		expectedOk   bool
+	}{
+		{
+			name:         "nil config",
+			stackCfg:     nil,
+			unitName:     "database",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "unit found",
+			stackCfg: &config.StackConfig{
+				Units: []*config.Unit{
+					{Name: "database", Path: "db", Source: "./database"},
+					{Name: "app", Path: "app", Source: "./app"},
+				},
+			},
+			unitName:     "database",
+			expectedPath: "db",
+			expectedOk:   true,
+		},
+		{
+			name: "unit not found",
+			stackCfg: &config.StackConfig{
+				Units: []*config.Unit{
+					{Name: "database", Path: "db", Source: "./database"},
+				},
+			},
+			unitName:     "missing",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "empty units",
+			stackCfg: &config.StackConfig{
+				Units: []*config.Unit{},
+			},
+			unitName:     "database",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, ok := stackutils.LookupUnitPath(tt.stackCfg, tt.unitName)
+
+			assert.Equal(t, tt.expectedOk, ok)
+			assert.Equal(t, tt.expectedPath, path)
+		})
+	}
+}
+
+func TestLookupStackPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		stackCfg     *config.StackConfig
+		stackName    string
+		expectedPath string
+		expectedOk   bool
+	}{
+		{
+			name:         "nil config",
+			stackCfg:     nil,
+			stackName:    "nested",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "stack found",
+			stackCfg: &config.StackConfig{
+				Stacks: []*config.Stack{
+					{Name: "nested", Path: "nested", Source: "./nested-stack"},
+					{Name: "other", Path: "other", Source: "./other-stack"},
+				},
+			},
+			stackName:    "nested",
+			expectedPath: "nested",
+			expectedOk:   true,
+		},
+		{
+			name: "stack not found",
+			stackCfg: &config.StackConfig{
+				Stacks: []*config.Stack{
+					{Name: "nested", Path: "nested", Source: "./nested-stack"},
+				},
+			},
+			stackName:    "missing",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+		{
+			name: "empty stacks",
+			stackCfg: &config.StackConfig{
+				Stacks: []*config.Stack{},
+			},
+			stackName:    "nested",
+			expectedPath: "",
+			expectedOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path, ok := stackutils.LookupStackPath(tt.stackCfg, tt.stackName)
+
+			assert.Equal(t, tt.expectedOk, ok)
+			assert.Equal(t, tt.expectedPath, path)
+		})
+	}
+}

--- a/internal/tg/completion/completion.go
+++ b/internal/tg/completion/completion.go
@@ -21,7 +21,7 @@ func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) 
 	case store.FileTypeStack:
 		candidates = newStackCompletions(position)
 	case store.FileTypeValues:
-		return []protocol.CompletionItem{}
+		candidates = newValuesCompletions(position)
 	case store.FileTypeUnknown:
 		return []protocol.CompletionItem{}
 	}
@@ -35,6 +35,43 @@ func GetCompletions(l logger.Logger, s store.Store, position protocol.Position) 
 	}
 
 	return completions
+}
+
+// createCompletionItem builds a snippet-style block CompletionItem (Kind=Class) whose
+// TextEdit replaces the text from the start of the current line to the cursor.
+// Used to reduce boilerplate across the stack and values block-completion lists.
+func createCompletionItem(label, docValue, newText string, position protocol.Position) protocol.CompletionItem {
+	return protocol.CompletionItem{
+		Label: label,
+		Documentation: protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: docValue,
+		},
+		Kind:             protocol.CompletionItemKindClass,
+		InsertTextFormat: protocol.InsertTextFormatSnippet,
+		TextEdit: &protocol.TextEdit{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: position.Line, Character: 0},
+				End:   protocol.Position{Line: position.Line, Character: position.Character},
+			},
+			NewText: newText,
+		},
+	}
+}
+
+// newValuesCompletions returns a list of completions for terragrunt.values.hcl files.
+func newValuesCompletions(position protocol.Position) []protocol.CompletionItem {
+	return []protocol.CompletionItem{
+		createCompletionItem(
+			"values",
+			`# values
+The values block is used to define dynamic values for units in Terragrunt stacks.`,
+			`values {
+	${1:key} = "${2:value}"
+}`,
+			position,
+		),
+	}
 }
 
 // newUnitCompletions returns a list of completions for terragrunt.hcl files.
@@ -425,64 +462,34 @@ The terragrunt_version_constraint attribute is used to specify which versions of
 // newStackCompletions returns a list of completions for terragrunt.stack.hcl files.
 func newStackCompletions(position protocol.Position) []protocol.CompletionItem {
 	return []protocol.CompletionItem{
-		{
-			Label: "unit",
-			Documentation: protocol.MarkupContent{
-				Kind: protocol.Markdown,
-				Value: `# unit
+		createCompletionItem(
+			"unit",
+			`# unit
 The unit block references a Terragrunt unit to include in this stack.`,
-			},
-			Kind:             protocol.CompletionItemKindClass,
-			InsertTextFormat: protocol.InsertTextFormatSnippet,
-			TextEdit: &protocol.TextEdit{
-				Range: protocol.Range{
-					Start: protocol.Position{Line: position.Line, Character: 0},
-					End:   protocol.Position{Line: position.Line, Character: position.Character},
-				},
-				NewText: `unit "${1}" {
+			`unit "${1}" {
 	source = "${2}"
 	path   = "${3}"
 }`,
-			},
-		},
-		{
-			Label: "stack",
-			Documentation: protocol.MarkupContent{
-				Kind: protocol.Markdown,
-				Value: `# stack
+			position,
+		),
+		createCompletionItem(
+			"stack",
+			`# stack
 The stack block references another Terragrunt stack to nest within this stack.`,
-			},
-			Kind:             protocol.CompletionItemKindClass,
-			InsertTextFormat: protocol.InsertTextFormatSnippet,
-			TextEdit: &protocol.TextEdit{
-				Range: protocol.Range{
-					Start: protocol.Position{Line: position.Line, Character: 0},
-					End:   protocol.Position{Line: position.Line, Character: position.Character},
-				},
-				NewText: `stack "${1}" {
+			`stack "${1}" {
 	source = "${2}"
 	path   = "${3}"
 }`,
-			},
-		},
-		{
-			Label: "locals",
-			Documentation: protocol.MarkupContent{
-				Kind: protocol.Markdown,
-				Value: `# locals
+			position,
+		),
+		createCompletionItem(
+			"locals",
+			`# locals
 The locals block defines aliases for expressions reusable within the stack file.`,
-			},
-			Kind:             protocol.CompletionItemKindClass,
-			InsertTextFormat: protocol.InsertTextFormatSnippet,
-			TextEdit: &protocol.TextEdit{
-				Range: protocol.Range{
-					Start: protocol.Position{Line: position.Line, Character: 0},
-					End:   protocol.Position{Line: position.Line, Character: position.Character},
-				},
-				NewText: `locals {
+			`locals {
 	${1} = ${2}
 }`,
-			},
-		},
+			position,
+		),
 	}
 }

--- a/internal/tg/completion/completion_test.go
+++ b/internal/tg/completion/completion_test.go
@@ -288,13 +288,50 @@ EOF
 			},
 		},
 		{
-			name: "values file - no completions",
+			name: "values file - no match for loc",
 			store: store.Store{
 				Document: `loc`,
 				FileType: store.FileTypeValues,
 			},
 			position:    protocol.Position{Line: 0, Character: 3},
 			completions: []protocol.CompletionItem{},
+		},
+		{
+			name: "values file - dep does not complete",
+			store: store.Store{
+				Document: `dep`,
+				FileType: store.FileTypeValues,
+			},
+			position:    protocol.Position{Line: 0, Character: 3},
+			completions: []protocol.CompletionItem{},
+		},
+		{
+			name: "values file - complete val",
+			store: store.Store{
+				Document: `val`,
+				FileType: store.FileTypeValues,
+			},
+			position: protocol.Position{Line: 0, Character: 3},
+			completions: []protocol.CompletionItem{
+				{
+					Label: "values",
+					Documentation: protocol.MarkupContent{
+						Kind:  protocol.Markdown,
+						Value: "# values\nThe values block is used to define dynamic values for units in Terragrunt stacks.",
+					},
+					Kind:             protocol.CompletionItemKindClass,
+					InsertTextFormat: protocol.InsertTextFormatSnippet,
+					TextEdit: &protocol.TextEdit{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 0, Character: 0},
+							End:   protocol.Position{Line: 0, Character: 3},
+						},
+						NewText: `values {
+	${1:key} = "${2:value}"
+}`,
+					},
+				},
+			},
 		},
 	}
 

--- a/internal/tg/definition/definition.go
+++ b/internal/tg/definition/definition.go
@@ -4,6 +4,7 @@ package definition
 
 import (
 	"terragrunt-ls/internal/ast"
+	astconfig "terragrunt-ls/internal/ast/config"
 	"terragrunt-ls/internal/logger"
 	"terragrunt-ls/internal/tg/store"
 
@@ -30,18 +31,20 @@ func GetDefinitionTargetWithContext(l logger.Logger, store store.Store, position
 		return "", DefinitionContextNull
 	}
 
-	node := store.AST.FindNodeAt(ast.ToHCLPos(position))
+	cfgAST := astconfig.NewConfigAST(store.AST)
+
+	node := cfgAST.FindNodeAt(ast.ToHCLPos(position))
 	if node == nil {
 		l.Debug("No node found at", "line", position.Line, "character", position.Character)
 		return "", DefinitionContextNull
 	}
 
-	if include, ok := ast.GetNodeIncludeLabel(node); ok {
+	if include, ok := cfgAST.GetIncludeLabel(node); ok {
 		l.Debug("Found include", "label", include)
 		return include, DefinitionContextInclude
 	}
 
-	if dep, ok := ast.GetNodeDependencyLabel(node); ok {
+	if dep, ok := cfgAST.GetDependencyLabel(node); ok {
 		l.Debug("Found dependency", "label", dep)
 		return dep, DefinitionContextDependency
 	}

--- a/internal/tg/definition/stack.go
+++ b/internal/tg/definition/stack.go
@@ -1,0 +1,257 @@
+// Package definition provides stack-specific go-to-definition functionality.
+package definition
+
+import (
+	"os"
+	"path/filepath"
+	"terragrunt-ls/internal/ast"
+	aststack "terragrunt-ls/internal/ast/stack"
+	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/stackutils"
+	"terragrunt-ls/internal/tg/store"
+
+	"github.com/gruntwork-io/terragrunt/pkg/config"
+	"go.lsp.dev/protocol"
+)
+
+const (
+	// DefinitionContextUnitSource is the context for navigating to a unit source location.
+	DefinitionContextUnitSource = "unit_source"
+
+	// DefinitionContextStackSource is the context for navigating to a stack source location.
+	DefinitionContextStackSource = "stack_source"
+
+	// DefinitionContextStackPath is the context for navigating to a resolved block path.
+	DefinitionContextStackPath = "stack_path"
+
+	// DefinitionContextStackUnit is the context for a unit block.
+	DefinitionContextStackUnit = "stack_unit"
+)
+
+// GetStackDefinitionTargetWithContext analyzes the position in a terragrunt.stack.hcl file
+// and returns navigation information with a classifying context.
+func GetStackDefinitionTargetWithContext(
+	l logger.Logger,
+	s store.Store,
+	position protocol.Position,
+	currentDir string,
+) (string, string) {
+	if s.AST == nil {
+		l.Debug("No AST found for stack file")
+		return "", DefinitionContextNull
+	}
+
+	stackAST := aststack.NewStackAST(s.AST)
+
+	pos := ast.ToHCLPos(position)
+	node := stackAST.FindNodeAt(pos)
+
+	if node == nil {
+		l.Debug("No node found at position", "line", position.Line, "character", position.Character)
+		return "", DefinitionContextNull
+	}
+
+	if _, ok := stackAST.FindUnitAt(pos); ok {
+		if source, ok := stackAST.GetUnitSource(node); ok {
+			l.Debug(
+				"Found unit source for definition",
+				"source", source,
+				"currentDir", currentDir,
+			)
+
+			return source, DefinitionContextUnitSource
+		}
+
+		if blockName, ok := stackAST.GetUnitLabel(node); ok {
+			if path, ok := stackutils.LookupUnitPath(s.StackCfg, blockName); ok {
+				l.Debug(
+					"Found unit path for definition from parsed config",
+					"blockName", blockName,
+					"path", path,
+					"currentDir", currentDir,
+				)
+
+				return resolveBlockPath(l, stackAST, s.StackCfg, node, path, currentDir, "unit")
+			}
+		}
+	}
+
+	if _, ok := stackAST.FindStackAt(pos); ok {
+		if source, ok := stackAST.GetStackSource(node); ok {
+			l.Debug(
+				"Found stack source for definition",
+				"source", source,
+				"currentDir", currentDir,
+			)
+
+			return source, DefinitionContextStackSource
+		}
+
+		if blockName, ok := stackAST.GetStackLabel(node); ok {
+			if path, ok := stackutils.LookupStackPath(s.StackCfg, blockName); ok {
+				l.Debug(
+					"Found stack path for definition from parsed config",
+					"blockName", blockName,
+					"path", path,
+					"currentDir", currentDir,
+				)
+
+				return resolveBlockPath(l, stackAST, s.StackCfg, node, path, currentDir, "stack")
+			}
+		}
+	}
+
+	l.Debug("No stack-specific definition target found")
+
+	return "", DefinitionContextNull
+}
+
+// ResolveUnitSourceLocation resolves a unit `source` to a Terraform file to open:
+// main.tf if present, else the first *.tf file, else the source directory itself.
+// Returns "" if the source directory does not exist.
+func ResolveUnitSourceLocation(source, currentDir string) string {
+	absPath := source
+	if !filepath.IsAbs(source) {
+		absPath = filepath.Join(currentDir, source)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	mainTF := filepath.Join(absPath, "main.tf")
+	if _, err := os.Stat(mainTF); err == nil {
+		return mainTF
+	}
+
+	entries, err := os.ReadDir(absPath)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			if filepath.Ext(entry.Name()) == ".tf" {
+				return filepath.Join(absPath, entry.Name())
+			}
+		}
+	}
+
+	return absPath
+}
+
+// ResolveStackSourceLocation resolves a stack `source` to the terragrunt.stack.hcl
+// inside that directory, falling back to the directory itself when the file is missing.
+// Returns "" if the directory does not exist.
+func ResolveStackSourceLocation(source, currentDir string) string {
+	absPath := source
+	if !filepath.IsAbs(source) {
+		absPath = filepath.Join(currentDir, source)
+	}
+
+	info, err := os.Stat(absPath)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+
+	stackFile := filepath.Join(absPath, "terragrunt.stack.hcl")
+	if _, err := os.Stat(stackFile); err == nil {
+		return stackFile
+	}
+
+	return absPath
+}
+
+// resolveBlockPath resolves a unit or stack block's `path` to the generated terragrunt.hcl,
+// honoring no_dot_terragrunt_stack when set on the matching block in the parsed config.
+func resolveBlockPath(
+	l logger.Logger,
+	stackAST aststack.StackAST,
+	stackCfg *config.StackConfig,
+	node *ast.IndexedNode,
+	path string,
+	currentDir string,
+	blockType string,
+) (string, string) {
+	var blockName string
+
+	var hasName bool
+
+	if blockType == "unit" {
+		blockName, hasName = stackAST.GetUnitLabel(node)
+	} else {
+		blockName, hasName = stackAST.GetStackLabel(node)
+	}
+
+	if !hasName {
+		l.Debug("Could not determine " + blockType + " name for path resolution")
+
+		resolved := filepath.Join(currentDir, ".terragrunt-stack", path, "terragrunt.hcl")
+		if _, err := os.Stat(resolved); err == nil {
+			return resolved, DefinitionContextStackPath
+		}
+
+		return "", DefinitionContextNull
+	}
+
+	noStack := false
+	if stackCfg != nil {
+		noStack = lookupNoStackConfig(stackCfg, blockName, blockType)
+	}
+
+	var resolved string
+	if noStack {
+		resolved = filepath.Join(currentDir, path, "terragrunt.hcl")
+	} else {
+		resolved = filepath.Join(currentDir, ".terragrunt-stack", path, "terragrunt.hcl")
+	}
+
+	if _, err := os.Stat(resolved); err == nil {
+		l.Debug("Resolved "+blockType+" path", "path", path, "resolved", resolved, "noStack", noStack)
+		return resolved, DefinitionContextStackPath
+	}
+
+	l.Debug("Could not resolve "+blockType+" path", "path", path, "resolved", resolved, "noStack", noStack)
+
+	return "", DefinitionContextNull
+}
+
+// lookupNoStackConfig reports the no_dot_terragrunt_stack setting for the named block in the
+// parsed stack config, or false if the block is missing or the setting is unset.
+func lookupNoStackConfig(stackCfg *config.StackConfig, blockName, blockType string) bool {
+	switch blockType {
+	case "unit":
+		for _, unit := range stackCfg.Units {
+			if unit.Name != blockName {
+				continue
+			}
+
+			if unit.NoStack != nil {
+				return *unit.NoStack
+			}
+
+			return false
+		}
+
+		return false
+
+	case "stack":
+		for _, stack := range stackCfg.Stacks {
+			if stack.Name != blockName {
+				continue
+			}
+
+			if stack.NoStack != nil {
+				return *stack.NoStack
+			}
+
+			return false
+		}
+
+		return false
+
+	default:
+		return false
+	}
+}

--- a/internal/tg/definition/stack_integration_test.go
+++ b/internal/tg/definition/stack_integration_test.go
@@ -1,0 +1,97 @@
+package definition_test
+
+import (
+	"path/filepath"
+	"terragrunt-ls/internal/testutils"
+	"terragrunt-ls/internal/tg"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+func TestStackDefinition_Integration(t *testing.T) {
+	t.Parallel()
+
+	content := `unit "database" {
+  source = "./database"
+  path   = "db"
+}
+
+stack "nested" {
+  source = "./nested-stack"
+  path   = "nested"
+}`
+
+	// Create a temporary file
+	tmpDir := t.TempDir()
+	filename := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+	docURI := uri.File(filename)
+
+	// Create logger
+	l := testutils.NewTestLogger(t)
+
+	// Create state and open document
+	state := tg.NewState()
+	diags := state.OpenDocument(t.Context(), l, docURI, content)
+	require.Empty(t, diags, "Expected no diagnostics")
+
+	tests := []struct {
+		name        string
+		description string
+		line        uint32
+		character   uint32
+		expectEmpty bool
+	}{
+		{
+			name:        "unit source attribute value",
+			line:        1,  // second line (0-indexed)
+			character:   15, // middle of "./database"
+			expectEmpty: false,
+			description: "clicking on unit source attribute value should provide definition",
+		},
+		{
+			name:        "stack source attribute value",
+			line:        5,  // sixth line (0-indexed)
+			character:   15, // middle of "./nested-stack"
+			expectEmpty: false,
+			description: "clicking on stack source attribute value should provide definition",
+		},
+		{
+			name:        "path attribute value",
+			line:        2,  // third line (0-indexed)
+			character:   10, // middle of "db"
+			expectEmpty: false,
+			description: "clicking on path attribute value should provide definition",
+		},
+		{
+			name:        "outside attributes",
+			line:        0, // first line
+			character:   5, // middle of "unit"
+			expectEmpty: true,
+			description: "clicking outside of source/path attributes should not provide definition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			position := protocol.Position{Line: tt.line, Character: tt.character}
+			defResponse := state.Definition(l, 1, docURI, position)
+
+			if tt.expectEmpty {
+				// For empty responses, the result URI should be the same as input (no navigation)
+				assert.Equal(t, docURI, defResponse.Result.URI, tt.description)
+				assert.Equal(t, position, defResponse.Result.Range.Start, tt.description)
+			} else {
+				// For valid definitions, we should get a different location or the resolved path
+				// The exact response depends on whether the path exists, but we shouldn't get an empty response
+				assert.NotEqual(t, protocol.Location{}, defResponse.Result, tt.description)
+				t.Logf("Definition result: %+v", defResponse.Result)
+			}
+		})
+	}
+}

--- a/internal/tg/definition/stack_test.go
+++ b/internal/tg/definition/stack_test.go
@@ -1,0 +1,208 @@
+package definition_test
+
+import (
+	"os"
+	"path/filepath"
+	"terragrunt-ls/internal/tg/definition"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveUnitSourceLocation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setupFunc     func(t *testing.T, tmpDir string) (source, currentDir string)
+		expectedFile  string // relative to tmpDir
+		shouldResolve bool
+	}{
+		{
+			name: "directory with main.tf",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				moduleDir := filepath.Join(tmpDir, "modules", "database")
+				require.NoError(t, os.MkdirAll(moduleDir, 0755))
+
+				// Create main.tf in the module directory
+				mainTF := filepath.Join(moduleDir, "main.tf")
+				require.NoError(t, os.WriteFile(mainTF, []byte("# main.tf"), 0644))
+
+				return "./modules/database", tmpDir
+			},
+			expectedFile:  "modules/database/main.tf",
+			shouldResolve: true,
+		},
+		{
+			name: "directory with other .tf files (no main.tf)",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				moduleDir := filepath.Join(tmpDir, "modules", "vpc")
+				require.NoError(t, os.MkdirAll(moduleDir, 0755))
+
+				// Create some .tf files (no main.tf)
+				require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte("# variables.tf"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "outputs.tf"), []byte("# outputs.tf"), 0644))
+
+				return "./modules/vpc", tmpDir
+			},
+			expectedFile:  "modules/vpc", // Will be validated differently since file order isn't guaranteed
+			shouldResolve: true,
+		},
+		{
+			name: "directory with both main.tf and other files",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				moduleDir := filepath.Join(tmpDir, "modules", "priority-test")
+				require.NoError(t, os.MkdirAll(moduleDir, 0755))
+
+				// Create both files - main.tf should have priority
+				require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("# main.tf"), 0644))
+				require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte("# variables.tf"), 0644))
+
+				return "./modules/priority-test", tmpDir
+			},
+			expectedFile:  "modules/priority-test/main.tf",
+			shouldResolve: true,
+		},
+		{
+			name: "directory with no terraform files",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				moduleDir := filepath.Join(tmpDir, "modules", "empty")
+				require.NoError(t, os.MkdirAll(moduleDir, 0755))
+
+				// Create a non-terraform file
+				require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "README.md"), []byte("# README"), 0644))
+
+				return "./modules/empty", tmpDir
+			},
+			expectedFile:  "modules/empty", // Should return the directory itself
+			shouldResolve: true,
+		},
+		{
+			name: "non-existent directory",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				return "./non-existent", tmpDir
+			},
+			expectedFile:  "",
+			shouldResolve: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			source, currentDir := tt.setupFunc(t, tmpDir)
+
+			resolved := definition.ResolveUnitSourceLocation(source, currentDir)
+
+			if tt.shouldResolve {
+				// Special handling for the "other .tf files" test case
+				if tt.name == "directory with other .tf files (no main.tf)" {
+					// Should resolve to one of the .tf files in the directory
+					moduleDir := filepath.Join(tmpDir, "modules", "vpc")
+					assert.True(t, resolved == filepath.Join(moduleDir, "variables.tf") ||
+						resolved == filepath.Join(moduleDir, "outputs.tf"),
+						"Resolved path should be one of the .tf files")
+				} else {
+					expectedPath := filepath.Join(tmpDir, tt.expectedFile)
+					assert.Equal(t, expectedPath, resolved, "Resolved path should match expected")
+				}
+
+				// Verify the resolved path exists
+				_, err := os.Stat(resolved)
+				assert.NoError(t, err, "Resolved path should exist")
+			} else {
+				assert.Empty(t, resolved, "Resolved path should be empty when resolution fails")
+			}
+		})
+	}
+}
+
+func TestResolveStackSourceLocation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		setupFunc     func(t *testing.T, tmpDir string) (source, currentDir string)
+		expectedFile  string // relative to tmpDir
+		shouldResolve bool
+	}{
+		{
+			name: "directory with terragrunt.stack.hcl",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				stackDir := filepath.Join(tmpDir, "stacks", "webapp")
+				require.NoError(t, os.MkdirAll(stackDir, 0755))
+
+				// Create terragrunt.stack.hcl in the stack directory
+				stackHCL := filepath.Join(stackDir, "terragrunt.stack.hcl")
+				require.NoError(t, os.WriteFile(stackHCL, []byte("# terragrunt.stack.hcl"), 0644))
+
+				return "./stacks/webapp", tmpDir
+			},
+			expectedFile:  "stacks/webapp/terragrunt.stack.hcl",
+			shouldResolve: true,
+		},
+		{
+			name: "directory with no stack file",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				stackDir := filepath.Join(tmpDir, "stacks", "empty")
+				require.NoError(t, os.MkdirAll(stackDir, 0755))
+
+				// Create a non-stack file
+				require.NoError(t, os.WriteFile(filepath.Join(stackDir, "README.md"), []byte("# README"), 0644))
+
+				return "./stacks/empty", tmpDir
+			},
+			expectedFile:  "stacks/empty", // Should return the directory itself
+			shouldResolve: true,
+		},
+		{
+			name: "non-existent directory",
+			setupFunc: func(t *testing.T, tmpDir string) (string, string) {
+				t.Helper()
+
+				return "./non-existent", tmpDir
+			},
+			expectedFile:  "",
+			shouldResolve: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			source, currentDir := tt.setupFunc(t, tmpDir)
+
+			resolved := definition.ResolveStackSourceLocation(source, currentDir)
+
+			if tt.shouldResolve {
+				expectedPath := filepath.Join(tmpDir, tt.expectedFile)
+				assert.Equal(t, expectedPath, resolved, "Resolved path should match expected")
+
+				// Verify the resolved path exists
+				_, err := os.Stat(resolved)
+				assert.NoError(t, err, "Resolved path should exist")
+			} else {
+				assert.Empty(t, resolved, "Resolved path should be empty when resolution fails")
+			}
+		})
+	}
+}

--- a/internal/tg/definition/values.go
+++ b/internal/tg/definition/values.go
@@ -1,0 +1,69 @@
+// Package definition provides values-specific go-to-definition functionality.
+package definition
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/tg/store"
+	"terragrunt-ls/internal/tg/text"
+
+	"go.lsp.dev/protocol"
+)
+
+const (
+	// DefinitionContextValuesDependency is the context for navigating to a dependency config
+	// referenced inside a terragrunt.values.hcl file.
+	DefinitionContextValuesDependency = "values_dependency"
+)
+
+// GetValuesDefinitionTargetWithContext analyzes the position in a terragrunt.values.hcl file
+// and returns navigation information with a classifying context.
+func GetValuesDefinitionTargetWithContext(l logger.Logger, s store.Store, position protocol.Position) (string, string) {
+	if s.AST == nil {
+		l.Debug("No AST found for values file")
+		return "", DefinitionContextNull
+	}
+
+	word := text.GetCursorWord(s.Document, position)
+	if len(word) == 0 {
+		l.Debug("No word found at position", "line", position.Line, "character", position.Character)
+		return "", DefinitionContextNull
+	}
+
+	if strings.Contains(word, ".") {
+		parts := strings.Split(word, ".")
+		if len(parts) >= 2 && parts[0] == "dependency" {
+			depName := parts[1]
+			l.Debug("Found dependency reference for definition", "dependency", depName, "word", word)
+
+			return depName, DefinitionContextValuesDependency
+		}
+	}
+
+	l.Debug("No values-specific definition target found", "word", word)
+
+	return "", DefinitionContextNull
+}
+
+// ResolveValuesDependencyPath looks for a dependency unit's terragrunt.hcl in the directory
+// structure around the values file, trying common sibling/parent layouts. Returns the first
+// match found, or "" if nothing is found.
+func ResolveValuesDependencyPath(dependencyName, valuesFile string) (string, bool) {
+	currentDir := filepath.Dir(valuesFile)
+
+	candidates := []string{
+		filepath.Join(currentDir, "..", dependencyName, "terragrunt.hcl"),
+		filepath.Join(currentDir, dependencyName, "terragrunt.hcl"),
+		filepath.Join(filepath.Dir(currentDir), dependencyName, "terragrunt.hcl"),
+	}
+
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, true
+		}
+	}
+
+	return "", false
+}

--- a/internal/tg/hover/stack.go
+++ b/internal/tg/hover/stack.go
@@ -1,0 +1,91 @@
+// Package hover provides stack-specific hover functionality.
+package hover
+
+import (
+	"terragrunt-ls/internal/ast"
+	aststack "terragrunt-ls/internal/ast/stack"
+	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/stackutils"
+	"terragrunt-ls/internal/tg/store"
+
+	"go.lsp.dev/protocol"
+)
+
+const (
+	// HoverContextStackUnit is the context for hovering over a unit block.
+	HoverContextStackUnit = "stack_unit"
+
+	// HoverContextStackSource is the context for hovering over a source attribute.
+	HoverContextStackSource = "stack_source"
+
+	// HoverContextStackPath is the context for hovering over a path attribute.
+	HoverContextStackPath = "stack_path"
+
+	// HoverContextStackBlock is the context for hovering over a stack block.
+	HoverContextStackBlock = "stack_block"
+)
+
+// GetStackHoverTargetWithContext analyzes the position in a terragrunt.stack.hcl file
+// and returns hover information with a classifying context.
+func GetStackHoverTargetWithContext(l logger.Logger, s store.Store, position protocol.Position) (string, string) {
+	if s.AST == nil {
+		l.Debug("No AST found for stack file")
+		return "", HoverContextNull
+	}
+
+	stackAST := aststack.NewStackAST(s.AST)
+
+	pos := ast.ToHCLPos(position)
+	node := stackAST.FindNodeAt(pos)
+
+	if node == nil {
+		l.Debug("No node found at position", "line", position.Line, "character", position.Character)
+		return "", HoverContextNull
+	}
+
+	if _, ok := stackAST.FindUnitAt(pos); ok {
+		if source, ok := stackAST.GetUnitSource(node); ok {
+			l.Debug("Found unit source hover", "source", source)
+			return source, HoverContextStackSource
+		}
+
+		if blockName, ok := stackAST.GetUnitLabel(node); ok {
+			if path, ok := stackutils.LookupUnitPath(s.StackCfg, blockName); ok {
+				l.Debug("Found unit path hover from parsed config", "blockName", blockName, "path", path)
+				return path, HoverContextStackPath
+			}
+		}
+
+		if unitBlock, ok := stackAST.FindUnitAt(pos); ok {
+			if unitLabel, ok := stackAST.GetUnitLabel(unitBlock); ok {
+				l.Debug("Found unit block (general) hover", "unit", unitLabel)
+				return unitLabel, HoverContextStackUnit
+			}
+		}
+	}
+
+	if _, ok := stackAST.FindStackAt(pos); ok {
+		if source, ok := stackAST.GetStackSource(node); ok {
+			l.Debug("Found stack source hover", "source", source)
+			return source, HoverContextStackSource
+		}
+
+		if blockName, ok := stackAST.GetStackLabel(node); ok {
+			if path, ok := stackutils.LookupStackPath(s.StackCfg, blockName); ok {
+				l.Debug("Found stack path hover from parsed config", "blockName", blockName, "path", path)
+				return path, HoverContextStackPath
+			}
+		}
+
+		if stackBlock, ok := stackAST.FindStackAt(pos); ok {
+			if stackLabel, ok := stackAST.GetStackLabel(stackBlock); ok {
+				l.Debug("Found stack block (general) hover", "stack", stackLabel)
+				return stackLabel, HoverContextStackBlock
+			}
+		}
+	}
+
+	l.Debug("No stack-specific hover target found")
+
+	return "", HoverContextNull
+}

--- a/internal/tg/hover/values.go
+++ b/internal/tg/hover/values.go
@@ -1,0 +1,48 @@
+// Package hover provides values-specific hover functionality.
+package hover
+
+import (
+	"strings"
+	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/tg/store"
+	"terragrunt-ls/internal/tg/text"
+
+	"go.lsp.dev/protocol"
+)
+
+const (
+	// HoverContextValuesVariable is the context for hovering over a variable in a values file.
+	HoverContextValuesVariable = "values_variable"
+
+	// HoverContextValuesDependency is the context for hovering over a dependency reference.
+	HoverContextValuesDependency = "values_dependency"
+)
+
+// GetValuesHoverTargetWithContext analyzes the position in a terragrunt.values.hcl file
+// and returns hover information with a classifying context.
+func GetValuesHoverTargetWithContext(l logger.Logger, s store.Store, position protocol.Position) (string, string) {
+	if s.AST == nil {
+		l.Debug("No AST found for values file")
+		return "", HoverContextNull
+	}
+
+	word := text.GetCursorWord(s.Document, position)
+	if len(word) == 0 {
+		l.Debug("No word found at position", "line", position.Line, "character", position.Character)
+		return "", HoverContextNull
+	}
+
+	if strings.Contains(word, ".") {
+		parts := strings.Split(word, ".")
+		if len(parts) >= 2 && parts[0] == "dependency" {
+			depName := parts[1]
+			l.Debug("Found dependency reference hover", "dependency", depName, "word", word)
+
+			return depName, HoverContextValuesDependency
+		}
+	}
+
+	l.Debug("Found potential variable hover", "variable", word)
+
+	return word, HoverContextValuesVariable
+}

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -131,7 +131,9 @@ func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, posi
 		return s.hoverUnit(l, id, st, position)
 	case store.FileTypeStack:
 		return s.hoverStack(l, id, st, position)
-	case store.FileTypeUnknown, store.FileTypeValues:
+	case store.FileTypeValues:
+		return s.hoverValues(l, id, st, position)
+	case store.FileTypeUnknown:
 		return newEmptyHoverResponse(id)
 	}
 
@@ -267,6 +269,53 @@ func newStackBlockHoverResponse(id int, stackName string) lsp.HoverResponse {
 	}
 }
 
+func (s *State) hoverValues(l logger.Logger, id int, st store.Store, position protocol.Position) lsp.HoverResponse {
+	target, context := hover.GetValuesHoverTargetWithContext(l, st, position)
+
+	l.Debug(
+		"Values hover with context",
+		"target", target,
+		"context", context,
+	)
+
+	if target == "" {
+		return newEmptyHoverResponse(id)
+	}
+
+	switch context {
+	case hover.HoverContextValuesVariable:
+		return newValuesVariableHoverResponse(id, target)
+	case hover.HoverContextValuesDependency:
+		return newValuesDependencyHoverResponse(id, target)
+	}
+
+	return newEmptyHoverResponse(id)
+}
+
+func newValuesVariableHoverResponse(id int, variable string) lsp.HoverResponse {
+	return lsp.HoverResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: lsp.HoverResult{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: "**Variable: `" + variable + "`**\n\nThis appears to be a variable defined in the values block.\n\nValues files are used to define dynamic input values for units in Terragrunt stacks.",
+			},
+		},
+	}
+}
+
+func newValuesDependencyHoverResponse(id int, dependency string) lsp.HoverResponse {
+	return lsp.HoverResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: lsp.HoverResult{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: "**Dependency: `" + dependency + "`**\n\nThis is a reference to a dependency unit defined elsewhere in your Terragrunt configuration.\n\nThe dependency must be declared before it can be referenced in a values file.",
+			},
+		},
+	}
+}
+
 func newEmptyHoverResponse(id int) lsp.HoverResponse {
 	return lsp.HoverResponse{
 		Response: lsp.Response{
@@ -294,7 +343,9 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 		return s.definitionUnit(l, id, st, docURI, position)
 	case store.FileTypeStack:
 		return s.definitionStack(l, id, st, docURI, position)
-	case store.FileTypeUnknown, store.FileTypeValues:
+	case store.FileTypeValues:
+		return s.definitionValues(l, id, st, docURI, position)
+	case store.FileTypeUnknown:
 		return newEmptyDefinitionResponse(id, docURI, position)
 	}
 
@@ -483,6 +534,32 @@ func (s *State) definitionStack(l logger.Logger, id int, st store.Store, docURI 
 		l.Debug("Could not resolve stack source location", "source", target)
 	case definition.DefinitionContextStackPath:
 		return newStackDefinitionResponse(id, target)
+	}
+
+	return newEmptyDefinitionResponse(id, docURI, position)
+}
+
+func (s *State) definitionValues(l logger.Logger, id int, st store.Store, docURI protocol.DocumentURI, position protocol.Position) lsp.DefinitionResponse {
+	target, context := definition.GetValuesDefinitionTargetWithContext(l, st, position)
+
+	l.Debug(
+		"Values definition discovered",
+		"target", target,
+		"context", context,
+	)
+
+	if target == "" {
+		return newEmptyDefinitionResponse(id, docURI, position)
+	}
+
+	//nolint:gocritic
+	switch context {
+	case definition.DefinitionContextValuesDependency:
+		if resolved, ok := definition.ResolveValuesDependencyPath(target, docURI.Filename()); ok {
+			return newStackDefinitionResponse(id, resolved)
+		}
+
+		l.Debug("Could not resolve values dependency path", "dependency", target)
 	}
 
 	return newEmptyDefinitionResponse(id, docURI, position)

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -123,17 +123,23 @@ func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, posi
 		"Hovering over character",
 		"uri", docURI,
 		"position", position,
+		"fileType", st.FileType,
 	)
 
-	if st.FileType != store.FileTypeUnit {
+	switch st.FileType {
+	case store.FileTypeUnit:
+		return s.hoverUnit(l, id, st, position)
+	case store.FileTypeStack:
+		return s.hoverStack(l, id, st, position)
+	case store.FileTypeUnknown, store.FileTypeValues:
 		return newEmptyHoverResponse(id)
 	}
 
-	l.Debug(
-		"Config",
-		"uri", docURI,
-		"config", st.Cfg,
-	)
+	return newEmptyHoverResponse(id)
+}
+
+func (s *State) hoverUnit(l logger.Logger, id int, st store.Store, position protocol.Position) lsp.HoverResponse {
+	l.Debug("Config", "config", st.Cfg)
 
 	word, context := hover.GetHoverTargetWithContext(l, st, position)
 
@@ -186,6 +192,81 @@ func (s *State) Hover(l logger.Logger, id int, docURI protocol.DocumentURI, posi
 	return newEmptyHoverResponse(id)
 }
 
+func (s *State) hoverStack(l logger.Logger, id int, st store.Store, position protocol.Position) lsp.HoverResponse {
+	target, context := hover.GetStackHoverTargetWithContext(l, st, position)
+
+	l.Debug(
+		"Stack hover with context",
+		"target", target,
+		"context", context,
+	)
+
+	if target == "" {
+		return newEmptyHoverResponse(id)
+	}
+
+	switch context {
+	case hover.HoverContextStackUnit:
+		return newStackUnitHoverResponse(id, target)
+	case hover.HoverContextStackSource:
+		return newStackSourceHoverResponse(id, target)
+	case hover.HoverContextStackPath:
+		return newStackPathHoverResponse(id, target)
+	case hover.HoverContextStackBlock:
+		return newStackBlockHoverResponse(id, target)
+	}
+
+	return newEmptyHoverResponse(id)
+}
+
+func newStackUnitHoverResponse(id int, unitName string) lsp.HoverResponse {
+	return lsp.HoverResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: lsp.HoverResult{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: "**Unit: `" + unitName + "`**\n\nA unit block defines a single infrastructure component in a Terragrunt stack.\n\nEach unit has a source (where the Terraform code lives) and a path (where it will be deployed).",
+			},
+		},
+	}
+}
+
+func newStackSourceHoverResponse(id int, source string) lsp.HoverResponse {
+	return lsp.HoverResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: lsp.HoverResult{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: "**Source: `" + source + "`**\n\nThe source attribute specifies where the Terraform module or configuration is located.\n\nThis can be a local path, Git repository, or other supported Terraform module sources.",
+			},
+		},
+	}
+}
+
+func newStackPathHoverResponse(id int, path string) lsp.HoverResponse {
+	return lsp.HoverResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: lsp.HoverResult{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: "**Path: `" + path + "`**\n\nThe path attribute specifies the relative directory where this unit will be deployed.\n\nThis path is relative to the stack directory and determines where Terragrunt will run commands for this unit.",
+			},
+		},
+	}
+}
+
+func newStackBlockHoverResponse(id int, stackName string) lsp.HoverResponse {
+	return lsp.HoverResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: lsp.HoverResult{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: "**Stack: `" + stackName + "`**\n\nA stack block defines a nested stack within the current stack.\n\nNested stacks allow you to organize and compose multiple related infrastructure units together.",
+			},
+		},
+	}
+}
+
 func newEmptyHoverResponse(id int) lsp.HoverResponse {
 	return lsp.HoverResponse{
 		Response: lsp.Response{
@@ -205,12 +286,22 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 		"Definition requested",
 		"uri", docURI,
 		"position", position,
+		"fileType", st.FileType,
 	)
 
-	if st.FileType != store.FileTypeUnit {
+	switch st.FileType {
+	case store.FileTypeUnit:
+		return s.definitionUnit(l, id, st, docURI, position)
+	case store.FileTypeStack:
+		return s.definitionStack(l, id, st, docURI, position)
+	case store.FileTypeUnknown, store.FileTypeValues:
 		return newEmptyDefinitionResponse(id, docURI, position)
 	}
 
+	return newEmptyDefinitionResponse(id, docURI, position)
+}
+
+func (s *State) definitionUnit(l logger.Logger, id int, st store.Store, docURI protocol.DocumentURI, position protocol.Position) lsp.DefinitionResponse {
 	target, context := definition.GetDefinitionTargetWithContext(l, st, position)
 
 	l.Debug(
@@ -357,6 +448,54 @@ func newEmptyDefinitionResponse(id int, docURI protocol.DocumentURI, position pr
 			Range: protocol.Range{
 				Start: position,
 				End:   position,
+			},
+		},
+	}
+}
+
+func (s *State) definitionStack(l logger.Logger, id int, st store.Store, docURI protocol.DocumentURI, position protocol.Position) lsp.DefinitionResponse {
+	currentDir := filepath.Dir(docURI.Filename())
+
+	target, context := definition.GetStackDefinitionTargetWithContext(l, st, position, currentDir)
+
+	l.Debug(
+		"Stack definition discovered",
+		"target", target,
+		"context", context,
+	)
+
+	if target == "" {
+		return newEmptyDefinitionResponse(id, docURI, position)
+	}
+
+	switch context {
+	case definition.DefinitionContextUnitSource:
+		if resolved := definition.ResolveUnitSourceLocation(target, currentDir); resolved != "" {
+			return newStackDefinitionResponse(id, resolved)
+		}
+
+		l.Debug("Could not resolve unit source location", "source", target)
+	case definition.DefinitionContextStackSource:
+		if resolved := definition.ResolveStackSourceLocation(target, currentDir); resolved != "" {
+			return newStackDefinitionResponse(id, resolved)
+		}
+
+		l.Debug("Could not resolve stack source location", "source", target)
+	case definition.DefinitionContextStackPath:
+		return newStackDefinitionResponse(id, target)
+	}
+
+	return newEmptyDefinitionResponse(id, docURI, position)
+}
+
+func newStackDefinitionResponse(id int, resolved string) lsp.DefinitionResponse {
+	return lsp.DefinitionResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: protocol.Location{
+			URI: uri.File(resolved),
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 0, Character: 0},
+				End:   protocol.Position{Line: 0, Character: 0},
 			},
 		},
 	}

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -611,20 +611,60 @@ func TestState_OpenDocument_ValuesFile(t *testing.T) {
 func TestState_Hover_StackFile(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-	stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
-	stackURI := uri.File(stackPath)
-
-	state := tg.NewState()
-	l := testutils.NewTestLogger(t)
-
-	_ = state.OpenDocument(t.Context(), l, stackURI, `unit "vpc" {
+	document := `unit "vpc" {
 	source = "./units/vpc"
 	path   = "vpc"
-}`)
+}
+`
 
-	hover := state.Hover(l, 1, stackURI, protocol.Position{Line: 0, Character: 0})
-	assert.Empty(t, hover.Result.Contents.Value)
+	tc := []struct {
+		name           string
+		expectFragment string
+		position       protocol.Position
+		expectNonEmpty bool
+	}{
+		{
+			name:           "outside blocks",
+			position:       protocol.Position{Line: 4, Character: 0},
+			expectNonEmpty: false,
+		},
+		{
+			name:           "unit source attribute",
+			position:       protocol.Position{Line: 1, Character: 15},
+			expectNonEmpty: true,
+			expectFragment: "Source",
+		},
+		{
+			name:           "unit path attribute",
+			position:       protocol.Position{Line: 2, Character: 12},
+			expectNonEmpty: true,
+			expectFragment: "Path",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
+			stackURI := uri.File(stackPath)
+
+			state := tg.NewState()
+			l := testutils.NewTestLogger(t)
+
+			_ = state.OpenDocument(t.Context(), l, stackURI, document)
+
+			hover := state.Hover(l, 1, stackURI, tt.position)
+
+			if tt.expectNonEmpty {
+				assert.NotEmpty(t, hover.Result.Contents.Value)
+				assert.Contains(t, hover.Result.Contents.Value, tt.expectFragment)
+			} else {
+				assert.Empty(t, hover.Result.Contents.Value)
+			}
+		})
+	}
 }
 
 func TestState_Hover_ValuesFile(t *testing.T) {
@@ -646,7 +686,14 @@ func TestState_Hover_ValuesFile(t *testing.T) {
 func TestState_Definition_StackFile(t *testing.T) {
 	t.Parallel()
 
+	// Seed a fake unit source directory so ResolveUnitSourceLocation
+	// can navigate to main.tf.
 	tmpDir := t.TempDir()
+	unitDir := filepath.Join(tmpDir, "units", "vpc")
+	require.NoError(t, os.MkdirAll(unitDir, 0o755))
+	mainTF := filepath.Join(unitDir, "main.tf")
+	require.NoError(t, os.WriteFile(mainTF, []byte("# main.tf"), 0o644))
+
 	stackPath := filepath.Join(tmpDir, "terragrunt.stack.hcl")
 	stackURI := uri.File(stackPath)
 
@@ -658,10 +705,22 @@ func TestState_Definition_StackFile(t *testing.T) {
 	path   = "vpc"
 }`)
 
-	pos := protocol.Position{Line: 0, Character: 0}
-	def := state.Definition(l, 1, stackURI, pos)
-	assert.Equal(t, stackURI, def.Result.URI)
-	assert.Equal(t, pos, def.Result.Range.Start)
+	t.Run("outside blocks returns empty definition", func(t *testing.T) {
+		t.Parallel()
+
+		pos := protocol.Position{Line: 3, Character: 1}
+		def := state.Definition(l, 1, stackURI, pos)
+		assert.Equal(t, stackURI, def.Result.URI)
+		assert.Equal(t, pos, def.Result.Range.Start)
+	})
+
+	t.Run("unit source jumps to main.tf", func(t *testing.T) {
+		t.Parallel()
+
+		pos := protocol.Position{Line: 1, Character: 15}
+		def := state.Definition(l, 1, stackURI, pos)
+		assert.Equal(t, uri.File(mainTF), def.Result.URI)
+	})
 }
 
 func TestState_TextDocumentFormatting(t *testing.T) {

--- a/internal/tg/state_test.go
+++ b/internal/tg/state_test.go
@@ -670,17 +670,93 @@ func TestState_Hover_StackFile(t *testing.T) {
 func TestState_Hover_ValuesFile(t *testing.T) {
 	t.Parallel()
 
+	tc := []struct {
+		name           string
+		document       string
+		expectFragment string
+		position       protocol.Position
+		expectNonEmpty bool
+	}{
+		{
+			name:           "plain variable",
+			document:       `some_var = "hello"`,
+			position:       protocol.Position{Line: 0, Character: 2},
+			expectNonEmpty: true,
+			expectFragment: "Variable",
+		},
+		{
+			name:           "dependency reference",
+			document:       `vpc_id = dependency.vpc.outputs.id`,
+			position:       protocol.Position{Line: 0, Character: 22},
+			expectNonEmpty: true,
+			expectFragment: "Dependency",
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			valuesPath := filepath.Join(tmpDir, "terragrunt.values.hcl")
+			valuesURI := uri.File(valuesPath)
+
+			state := tg.NewState()
+			l := testutils.NewTestLogger(t)
+
+			_ = state.OpenDocument(t.Context(), l, valuesURI, tt.document)
+
+			hover := state.Hover(l, 1, valuesURI, tt.position)
+
+			if tt.expectNonEmpty {
+				assert.NotEmpty(t, hover.Result.Contents.Value)
+				assert.Contains(t, hover.Result.Contents.Value, tt.expectFragment)
+			} else {
+				assert.Empty(t, hover.Result.Contents.Value)
+			}
+		})
+	}
+}
+
+func TestState_Definition_ValuesFile(t *testing.T) {
+	t.Parallel()
+
+	// Seed a fake dependency unit directory structure:
+	// tmp/
+	//   values/terragrunt.values.hcl (the file under test)
+	//   vpc/terragrunt.hcl          (the dependency)
 	tmpDir := t.TempDir()
-	valuesPath := filepath.Join(tmpDir, "terragrunt.values.hcl")
+	valuesDir := filepath.Join(tmpDir, "values")
+	require.NoError(t, os.MkdirAll(valuesDir, 0o755))
+	depDir := filepath.Join(tmpDir, "vpc")
+	require.NoError(t, os.MkdirAll(depDir, 0o755))
+	depFile := filepath.Join(depDir, "terragrunt.hcl")
+	require.NoError(t, os.WriteFile(depFile, []byte(""), 0o644))
+
+	valuesPath := filepath.Join(valuesDir, "terragrunt.values.hcl")
 	valuesURI := uri.File(valuesPath)
 
 	state := tg.NewState()
 	l := testutils.NewTestLogger(t)
 
-	_ = state.OpenDocument(t.Context(), l, valuesURI, `some_var = "hello"`)
+	_ = state.OpenDocument(t.Context(), l, valuesURI, `vpc_id = dependency.vpc.outputs.id`)
 
-	hover := state.Hover(l, 1, valuesURI, protocol.Position{Line: 0, Character: 0})
-	assert.Empty(t, hover.Result.Contents.Value)
+	t.Run("dependency reference jumps to terragrunt.hcl", func(t *testing.T) {
+		t.Parallel()
+
+		pos := protocol.Position{Line: 0, Character: 22}
+		def := state.Definition(l, 1, valuesURI, pos)
+		assert.Equal(t, uri.File(depFile), def.Result.URI)
+	})
+
+	t.Run("plain variable returns empty definition", func(t *testing.T) {
+		t.Parallel()
+
+		pos := protocol.Position{Line: 0, Character: 2}
+		def := state.Definition(l, 1, valuesURI, pos)
+		assert.Equal(t, valuesURI, def.Result.URI)
+		assert.Equal(t, pos, def.Result.Range.Start)
+	})
 }
 
 func TestState_Definition_StackFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Ports #55's completion enhancements while keeping main's `store.FileType` as the canonical enum (deliberately does **not** introduce PR #55's duplicate `TerragruntFileType`).

- `createCompletionItem` helper reduces snippet-construction boilerplate across block completions (all `Kind=Class`).
- `newStackCompletions` refactored to use the helper.
- `newValuesCompletions` added with `values` and `dependency` block snippets; `FileTypeValues` now routes through it (previously returned an empty list).
- Tests: positive cases for values-file routing (`dep` \u2192 `dependency`, `val` \u2192 `values`).

Stacked on #130. Final PR in the four-part cherry-pick of #55.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/...`
- [x] `golangci-lint run` \u2014 0 issues
- [ ] Manual: in VS Code dev mode, type `dep` inside a `terragrunt.values.hcl` and confirm the `dependency` snippet appears.