### PR TITLE
ci: derive VS Code extension version from release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,15 @@ jobs:
         run: npm ci
         working-directory: vscode-extension
 
+      # TODO: revisit — package.json keeps a stale version in-tree and only
+      # gets rewritten here at release time. Long-term we should keep the
+      # committed version in sync (e.g. bump on release PR) instead of
+      # deriving it from the tag.
+      - name: Set extension version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        working-directory: vscode-extension
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
+
       - name: Package VSIX
         run: npx @vscode/vsce package --target ${{ matrix.vsce_target }}
         working-directory: vscode-extension


### PR DESCRIPTION
## Summary
- The release workflow failed on the `Publish to Marketplace` step because `package.json` was pinned to `0.0.1`, which already exists in the marketplace ([failed run](https://github.com/gruntwork-io/terragrunt-ls/actions/runs/24603977033/job/71947198123)).
- Rewrite the extension version from the release tag (`v1.2.3` → `1.2.3`) before packaging, so each tagged release publishes a unique version without needing a manual `package.json` bump per release.
- Left a `TODO` comment flagging that the committed `package.json` version is intentionally stale; long-term we should keep it in sync (e.g. bump on the release PR) rather than derive it from the tag.

## Test plan
- [ ] Cut a test tag (or re-run the failed workflow) and confirm each `*.vsix` is packaged with the tag version.
- [ ] Confirm `Publish to Marketplace` succeeds for all six `vsce_target` matrix entries.
- [ ] Confirm `workflow_dispatch` runs (no tag) still package successfully using the in-tree version.