### PR TITLE
fix: recover from upstream parser panic to keep LS alive

### DIFF
--- a/internal/tg/parse.go
+++ b/internal/tg/parse.go
@@ -2,8 +2,10 @@ package tg
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"terragrunt-ls/internal/logger"
@@ -52,11 +54,27 @@ func newParsingContext(ctx context.Context, tgLogger tgLog.Logger, filename stri
 	return ctx, pctx, parseDiags
 }
 
+// safeParseConfigString invokes config.ParseConfigString while guarding against
+// panics raised inside the upstream Terragrunt parser. A language server must
+// never crash because of user input: a panic here would take the LS process
+// down and disable diagnostics for every open editor window. Any recovered
+// panic is converted to an error and logged.
+func safeParseConfigString(ctx context.Context, pctx *config.ParsingContext, tgLogger tgLog.Logger, filename, text string) (cfg *config.TerragruntConfig, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while parsing Terragrunt config %q: %v\n%s", filename, r, debug.Stack())
+			cfg = nil
+		}
+	}()
+
+	return config.ParseConfigString(ctx, pctx, tgLogger, filename, text, nil)
+}
+
 func ParseTerragruntBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.TerragruntConfig, []protocol.Diagnostic) {
 	tgLogger := newTGLogger(l)
 	ctx, pctx, parseDiags := newParsingContext(ctx, tgLogger, filename)
 
-	cfg, err := config.ParseConfigString(ctx, pctx, tgLogger, filename, text, nil)
+	cfg, err := safeParseConfigString(ctx, pctx, tgLogger, filename, text)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing Terragrunt config", "error", err)
@@ -257,12 +275,26 @@ func DetectFileType(filename string) store.FileType {
 	}
 }
 
+// safeReadStackConfigString invokes config.ReadStackConfigString while guarding
+// against panics raised inside the upstream Terragrunt parser. See
+// safeParseConfigString for rationale.
+func safeReadStackConfigString(ctx context.Context, tgLogger tgLog.Logger, pctx *config.ParsingContext, filename, text string) (cfg *config.StackConfig, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic while parsing Terragrunt stack config %q: %v\n%s", filename, r, debug.Stack())
+			cfg = nil
+		}
+	}()
+
+	return config.ReadStackConfigString(ctx, tgLogger, pctx, filename, text, nil)
+}
+
 // ParseStackBuffer parses a terragrunt.stack.hcl file and returns the stack config and diagnostics.
 func ParseStackBuffer(ctx context.Context, l logger.Logger, filename, text string) (*config.StackConfig, []protocol.Diagnostic) {
 	tgLogger := newTGLogger(l)
 	ctx, pctx, parseDiags := newParsingContext(ctx, tgLogger, filename)
 
-	cfg, err := config.ReadStackConfigString(ctx, tgLogger, pctx, filename, text, nil)
+	cfg, err := safeReadStackConfigString(ctx, tgLogger, pctx, filename, text)
 	if err != nil {
 		// Just log the error for now
 		l.Error("Error parsing stack config", "error", err)

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -260,3 +260,65 @@ inputs = {
 		})
 	}
 }
+
+// TestParseTerragruntBuffer_DoesNotPanic is a regression test for
+// gruntwork-io/terragrunt-ls#134, where opening a root.hcl that uses
+// read_terragrunt_config / find_in_parent_folders together with a remote_state
+// block caused the upstream Terragrunt parser to panic with a nil-pointer
+// dereference, crashing the language server. Whatever the underlying behavior,
+// the LS must not panic on user input — it should return whatever it can and
+// log the error.
+func TestParseTerragruntBuffer_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// This is a reduced version of the user's reproducer from issue #134.
+	// The remote_state config references locals that depend on
+	// read_terragrunt_config calls whose target files do not exist, so the
+	// remote_state block cannot be fully resolved during LS parsing.
+	const rootHCL = `
+locals {
+  account_vars = read_terragrunt_config(find_in_parent_folders("account.hcl"))
+
+  terraform_state_bucket = try(
+    local.account_vars.locals.terraform_state_bucket,
+    "fallback-bucket",
+  )
+  terraform_assume_role_arn = try(
+    local.account_vars.locals.terraform_assume_role_arn,
+    "",
+  )
+}
+
+remote_state {
+  backend = "s3"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = merge({
+    bucket  = local.terraform_state_bucket
+    key     = "${path_relative_to_include()}/terraform.tfstate"
+    region  = "us-east-1"
+    encrypt = true
+    },
+    local.terraform_assume_role_arn != "" ? {
+      assume_role = {
+        role_arn = local.terraform_assume_role_arn
+      }
+  } : {})
+}
+`
+
+	tmpDir := t.TempDir()
+	filename := filepath.Join(tmpDir, "root.hcl")
+
+	l := testutils.NewTestLogger(t)
+
+	// The call must not panic. We deliberately do not assert on the returned
+	// cfg/diags shape: the goal is to prove the LS survives malformed or
+	// unresolvable inputs that previously caused a panic in the upstream
+	// Terragrunt parser.
+	require.NotPanics(t, func() {
+		tg.ParseTerragruntBuffer(context.Background(), l, filename, rootHCL)
+	})
+}

--- a/internal/tg/parse_test.go
+++ b/internal/tg/parse_test.go
@@ -266,7 +266,7 @@ inputs = {
 // read_terragrunt_config / find_in_parent_folders together with a remote_state
 // block caused the upstream Terragrunt parser to panic with a nil-pointer
 // dereference, crashing the language server. Whatever the underlying behavior,
-// the LS must not panic on user input — it should return whatever it can and
+// the LS must not panic on user input, it should return whatever it can and
 // log the error.
 func TestParseTerragruntBuffer_DoesNotPanic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #134.

When opening a `root.hcl` whose `remote_state` block depends on values produced by `read_terragrunt_config` / `find_in_parent_folders` that cannot be resolved during LS parsing, the upstream Terragrunt parser passes a nil `*remotestate.Config` to `remotestate.New`, which dereferences `config.BackendName` and panics. Because the parser runs in-process, the LS crashes for every open editor window.

This change wraps `config.ParseConfigString` and `config.ReadStackConfigString` in `recover()` shims at the LS boundary so a panic becomes a logged error and a nil config, matching the parser's existing error path. A regression test based on the reporter's reproducer is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration parsing reliability by converting internal crashes into returned errors and preserving stack details to aid debugging.

* **Tests**
  * Added a regression test to ensure malformed or unresolvable configs no longer cause the application to panic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gruntwork-io/terragrunt-ls/pull/140)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->