### PR TITLE
feat: rename, references, and go-to-definition for locals

### DIFF
--- a/internal/ast/walk.go
+++ b/internal/ast/walk.go
@@ -1,0 +1,58 @@
+package ast
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// MinReferenceTraversalLen is the minimum number of steps a ScopeTraversalExpr
+// must have to be a `<root>.<name>` reference (one root + one attribute).
+const MinReferenceTraversalLen = 2
+
+// ReferenceVisitor is invoked for each `<root>.<name>` reference found.
+// r is the source range of the attribute step (just `<name>`, not the root).
+type ReferenceVisitor func(expr *hclsyntax.ScopeTraversalExpr, r hcl.Range)
+
+// WalkReferences walks body and invokes visitor for each ScopeTraversalExpr
+// whose first traversal step is a TraverseRoot named root and whose second
+// step is a TraverseAttr named name.
+func WalkReferences(body *hclsyntax.Body, root, name string, visitor ReferenceVisitor) {
+	if body == nil {
+		return
+	}
+
+	_ = hclsyntax.VisitAll(body, func(node hclsyntax.Node) hcl.Diagnostics {
+		expr, ok := node.(*hclsyntax.ScopeTraversalExpr)
+		if !ok {
+			return nil
+		}
+
+		if len(expr.Traversal) < MinReferenceTraversalLen {
+			return nil
+		}
+
+		rootStep, ok := expr.Traversal[0].(hcl.TraverseRoot)
+		if !ok || rootStep.Name != root {
+			return nil
+		}
+
+		attrStep, ok := expr.Traversal[1].(hcl.TraverseAttr)
+		if !ok || attrStep.Name != name {
+			return nil
+		}
+
+		visitor(expr, TraverseAttrIdentRange(attrStep))
+
+		return nil
+	})
+}
+
+// TraverseAttrIdentRange returns the range of the attribute identifier alone,
+// excluding the leading dot included in TraverseAttr.SrcRange.
+func TraverseAttrIdentRange(step hcl.TraverseAttr) hcl.Range {
+	r := step.SrcRange
+	r.Start.Column++
+	r.Start.Byte++
+
+	return r
+}

--- a/internal/ast/walk_test.go
+++ b/internal/ast/walk_test.go
@@ -53,18 +53,6 @@ inputs = {
 			},
 		},
 		{
-			name: "dependency outputs reference",
-			contents: `inputs = {
-  v = dependency.vpc.outputs.id
-}
-`,
-			root:  "dependency",
-			ident: "vpc",
-			expected: []hcl.Range{
-				{Start: hcl.Pos{Line: 2, Column: 18}, End: hcl.Pos{Line: 2, Column: 21}},
-			},
-		},
-		{
 			name: "no matches",
 			contents: `inputs = {
   v = local.bar

--- a/internal/ast/walk_test.go
+++ b/internal/ast/walk_test.go
@@ -1,0 +1,104 @@
+package ast_test
+
+import (
+	"terragrunt-ls/internal/ast"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWalkReferences(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name     string
+		contents string
+		root     string
+		ident    string
+		expected []hcl.Range
+	}{
+		{
+			name: "single local reference",
+			contents: `locals {
+  foo = "bar"
+}
+
+inputs = {
+  v = local.foo
+}
+`,
+			root:  "local",
+			ident: "foo",
+			expected: []hcl.Range{
+				{Start: hcl.Pos{Line: 6, Column: 13}, End: hcl.Pos{Line: 6, Column: 16}},
+			},
+		},
+		{
+			name: "multiple references and unrelated traversals",
+			contents: `inputs = {
+  a = local.foo
+  b = local.bar
+  c = local.foo
+  d = path.module
+}
+`,
+			root:  "local",
+			ident: "foo",
+			expected: []hcl.Range{
+				{Start: hcl.Pos{Line: 2, Column: 13}, End: hcl.Pos{Line: 2, Column: 16}},
+				{Start: hcl.Pos{Line: 4, Column: 13}, End: hcl.Pos{Line: 4, Column: 16}},
+			},
+		},
+		{
+			name: "dependency outputs reference",
+			contents: `inputs = {
+  v = dependency.vpc.outputs.id
+}
+`,
+			root:  "dependency",
+			ident: "vpc",
+			expected: []hcl.Range{
+				{Start: hcl.Pos{Line: 2, Column: 18}, End: hcl.Pos{Line: 2, Column: 21}},
+			},
+		},
+		{
+			name: "no matches",
+			contents: `inputs = {
+  v = local.bar
+}
+`,
+			root:     "local",
+			ident:    "foo",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			iast, err := ast.ParseHCLFile("test.hcl", []byte(tt.contents))
+			require.NoError(t, err)
+			require.NotNil(t, iast.HCLFile)
+
+			body, ok := iast.HCLFile.Body.(*hclsyntax.Body)
+			require.True(t, ok)
+
+			var got []hcl.Range
+			ast.WalkReferences(body, tt.root, tt.ident, func(_ *hclsyntax.ScopeTraversalExpr, r hcl.Range) {
+				got = append(got, r)
+			})
+
+			require.Len(t, got, len(tt.expected))
+			for i := range tt.expected {
+				assert.Equal(t, tt.expected[i].Start.Line, got[i].Start.Line, "start line %d", i)
+				assert.Equal(t, tt.expected[i].Start.Column, got[i].Start.Column, "start col %d", i)
+				assert.Equal(t, tt.expected[i].End.Line, got[i].End.Line, "end line %d", i)
+				assert.Equal(t, tt.expected[i].End.Column, got[i].End.Column, "end col %d", i)
+			}
+		})
+	}
+}

--- a/internal/lsp/initialize.go
+++ b/internal/lsp/initialize.go
@@ -30,6 +30,9 @@ func NewInitializeResponse(id int) InitializeResponse {
 				DefinitionProvider:         true,
 				CompletionProvider:         &protocol.CompletionOptions{},
 				DocumentFormattingProvider: true,
+				RenameProvider: &protocol.RenameOptions{
+					PrepareProvider: true,
+				},
 			},
 			ServerInfo: &protocol.ServerInfo{
 				Name:    name,

--- a/internal/lsp/initialize.go
+++ b/internal/lsp/initialize.go
@@ -28,6 +28,7 @@ func NewInitializeResponse(id int) InitializeResponse {
 				TextDocumentSync:           1,
 				HoverProvider:              true,
 				DefinitionProvider:         true,
+				ReferencesProvider:         true,
 				CompletionProvider:         &protocol.CompletionOptions{},
 				DocumentFormattingProvider: true,
 				RenameProvider: &protocol.RenameOptions{

--- a/internal/lsp/rename.go
+++ b/internal/lsp/rename.go
@@ -1,0 +1,29 @@
+package lsp
+
+import "go.lsp.dev/protocol"
+
+type PrepareRenameRequest struct {
+	Request
+	Params protocol.PrepareRenameParams `json:"params"`
+}
+
+// PrepareRenameResult mirrors the LSP `{ range, placeholder }` response shape.
+type PrepareRenameResult struct {
+	Placeholder string         `json:"placeholder"`
+	Range       protocol.Range `json:"range"`
+}
+
+type PrepareRenameResponse struct {
+	Result *PrepareRenameResult `json:"result"`
+	Response
+}
+
+type RenameRequest struct {
+	Params protocol.RenameParams `json:"params"`
+	Request
+}
+
+type RenameResponse struct {
+	Result *protocol.WorkspaceEdit `json:"result"`
+	Response
+}

--- a/internal/lsp/textdocument_references.go
+++ b/internal/lsp/textdocument_references.go
@@ -1,0 +1,13 @@
+package lsp
+
+import "go.lsp.dev/protocol"
+
+type ReferencesRequest struct {
+	Params protocol.ReferenceParams `json:"params"`
+	Request
+}
+
+type ReferencesResponse struct {
+	Response
+	Result []protocol.Location `json:"result"`
+}

--- a/internal/tg/definition/definition.go
+++ b/internal/tg/definition/definition.go
@@ -7,10 +7,18 @@ import (
 	"terragrunt-ls/internal/logger"
 	"terragrunt-ls/internal/tg/store"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"go.lsp.dev/protocol"
 )
 
 const (
+	// DefinitionContextLocal is the context for a local variable definition.
+	// This means that the user is trying to find the definition of a `local.X`
+	// reference, which resolves to a `locals { X = ... }` declaration in the
+	// current file or a sibling file in the same module folder.
+	DefinitionContextLocal = "local"
+
 	// DefinitionContextInclude is the context for an include definition.
 	// This means that the user is trying to find the definition of an include.
 	DefinitionContextInclude = "include"
@@ -46,7 +54,43 @@ func GetDefinitionTargetWithContext(l logger.Logger, store store.Store, position
 		return dep, DefinitionContextDependency
 	}
 
+	if expr, ok := node.Node.(*hclsyntax.ScopeTraversalExpr); ok {
+		if name, context, ok := traversalDefinitionTarget(expr); ok {
+			l.Debug("Found traversal target", "name", name, "context", context)
+			return name, context
+		}
+	}
+
 	l.Debug("No definition found at", "line", position.Line, "character", position.Character)
 
 	return "", DefinitionContextNull
+}
+
+// traversalDefinitionTarget extracts a (name, context) pair from a
+// `<root>.<name>` traversal where root is one of local/include/dependency.
+func traversalDefinitionTarget(expr *hclsyntax.ScopeTraversalExpr) (string, string, bool) {
+	if len(expr.Traversal) < ast.MinReferenceTraversalLen {
+		return "", "", false
+	}
+
+	rootStep, ok := expr.Traversal[0].(hcl.TraverseRoot)
+	if !ok {
+		return "", "", false
+	}
+
+	attrStep, ok := expr.Traversal[1].(hcl.TraverseAttr)
+	if !ok {
+		return "", "", false
+	}
+
+	switch rootStep.Name {
+	case "local":
+		return attrStep.Name, DefinitionContextLocal, true
+	case "include":
+		return attrStep.Name, DefinitionContextInclude, true
+	case "dependency":
+		return attrStep.Name, DefinitionContextDependency, true
+	}
+
+	return "", "", false
 }

--- a/internal/tg/definition/definition.go
+++ b/internal/tg/definition/definition.go
@@ -83,11 +83,8 @@ func traversalDefinitionTarget(expr *hclsyntax.ScopeTraversalExpr) (string, stri
 		return "", "", false
 	}
 
-	switch rootStep.Name {
-	case "local":
+	if rootStep.Name == "local" {
 		return attrStep.Name, DefinitionContextLocal, true
-	case "dependency":
-		return attrStep.Name, DefinitionContextDependency, true
 	}
 
 	return "", "", false

--- a/internal/tg/definition/definition.go
+++ b/internal/tg/definition/definition.go
@@ -67,7 +67,7 @@ func GetDefinitionTargetWithContext(l logger.Logger, store store.Store, position
 }
 
 // traversalDefinitionTarget extracts a (name, context) pair from a
-// `<root>.<name>` traversal where root is one of local/include/dependency.
+// `local.<name>` traversal.
 func traversalDefinitionTarget(expr *hclsyntax.ScopeTraversalExpr) (string, string, bool) {
 	if len(expr.Traversal) < ast.MinReferenceTraversalLen {
 		return "", "", false

--- a/internal/tg/definition/definition.go
+++ b/internal/tg/definition/definition.go
@@ -86,8 +86,6 @@ func traversalDefinitionTarget(expr *hclsyntax.ScopeTraversalExpr) (string, stri
 	switch rootStep.Name {
 	case "local":
 		return attrStep.Name, DefinitionContextLocal, true
-	case "include":
-		return attrStep.Name, DefinitionContextInclude, true
 	case "dependency":
 		return attrStep.Name, DefinitionContextDependency, true
 	}

--- a/internal/tg/references/references.go
+++ b/internal/tg/references/references.go
@@ -1,5 +1,5 @@
 // Package references provides the logic for finding all references of an
-// identifier across a Terragrunt module.
+// identifier within a Terragrunt unit.
 package references
 
 import (
@@ -14,13 +14,13 @@ import (
 // GetReferences returns LSP locations for every reference (and optionally the
 // declaration) of the renameable symbol at position. Returns nil if the cursor
 // is not on a renameable identifier.
-func GetReferences(l logger.Logger, st store.Store, position protocol.Position, originFile string, configs map[string]store.Store, includeDeclaration bool) []protocol.Location {
+func GetReferences(l logger.Logger, st store.Store, position protocol.Position, file string, includeDeclaration bool) []protocol.Location {
 	target := rename.GetRenameTarget(l, st, position)
 	if target.Context == rename.RenameContextNull {
 		return nil
 	}
 
-	occurrences := rename.FindAllOccurrences(l, target, originFile, configs)
+	occurrences := rename.FindAllOccurrences(target, file, st)
 	if len(occurrences) == 0 {
 		return nil
 	}

--- a/internal/tg/references/references.go
+++ b/internal/tg/references/references.go
@@ -1,0 +1,42 @@
+// Package references provides the logic for finding all references of an
+// identifier across a Terragrunt module.
+package references
+
+import (
+	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/tg/rename"
+	"terragrunt-ls/internal/tg/store"
+
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+// GetReferences returns LSP locations for every reference (and optionally the
+// declaration) of the renameable symbol at position. Returns nil if the cursor
+// is not on a renameable identifier.
+func GetReferences(l logger.Logger, st store.Store, position protocol.Position, originFile string, configs map[string]store.Store, includeDeclaration bool) []protocol.Location {
+	target := rename.GetRenameTarget(l, st, position)
+	if target.Context == rename.RenameContextNull {
+		return nil
+	}
+
+	occurrences := rename.FindAllOccurrences(l, target, originFile, configs)
+	if len(occurrences) == 0 {
+		return nil
+	}
+
+	locations := make([]protocol.Location, 0, len(occurrences))
+
+	for _, occ := range occurrences {
+		if occ.IsDefinition && !includeDeclaration {
+			continue
+		}
+
+		locations = append(locations, protocol.Location{
+			URI:   uri.File(occ.File),
+			Range: occ.Range,
+		})
+	}
+
+	return locations
+}

--- a/internal/tg/references/references_test.go
+++ b/internal/tg/references/references_test.go
@@ -1,7 +1,6 @@
 package references_test
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -43,7 +42,7 @@ inputs = {
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
 
 	t.Run("includes declaration when requested", func(t *testing.T) {
 		t.Parallel()

--- a/internal/tg/references/references_test.go
+++ b/internal/tg/references/references_test.go
@@ -1,0 +1,99 @@
+package references_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"terragrunt-ls/internal/testutils"
+	"terragrunt-ls/internal/tg"
+	"terragrunt-ls/internal/tg/references"
+)
+
+func TestGetReferences(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	commonContent := `locals {
+  shared = "value"
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
+	require.NoError(t, err)
+
+	tgContent := `include "common" {
+  path = "common.hcl"
+}
+
+inputs = {
+  v = local.shared
+}
+`
+	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	commonPath := filepath.Join(tmpDir, "common.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+
+	t.Run("includes declaration when requested", func(t *testing.T) {
+		t.Parallel()
+
+		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14}, tgPath, s.Configs, true)
+		require.Len(t, locs, 2, "definition + reference")
+
+		// Sorted by file name then position; common.hcl comes first alphabetically.
+		assert.Equal(t, uri.File(commonPath), locs[0].URI)
+		assert.Equal(t, uri.File(tgPath), locs[1].URI)
+	})
+
+	t.Run("excludes declaration when requested", func(t *testing.T) {
+		t.Parallel()
+
+		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14}, tgPath, s.Configs, false)
+		require.Len(t, locs, 1, "only the reference, not the definition")
+
+		assert.Equal(t, uri.File(tgPath), locs[0].URI)
+	})
+
+	t.Run("returns nil for non-renameable position", func(t *testing.T) {
+		t.Parallel()
+
+		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 0}, tgPath, s.Configs, true)
+		assert.Nil(t, locs)
+	})
+}
+
+func TestGetReferences_DependencyLabel(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	content := `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.id
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
+
+	// Cursor on the reference (`vpc` in dependency.vpc.outputs.id).
+	locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 23}, tgPath, s.Configs, true)
+	require.Len(t, locs, 2, "label definition + outputs reference")
+}

--- a/internal/tg/references/references_test.go
+++ b/internal/tg/references/references_test.go
@@ -72,28 +72,3 @@ inputs = {
 		assert.Nil(t, locs)
 	})
 }
-
-func TestGetReferences_DependencyLabel(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-	content := `dependency "vpc" {
-  config_path = "../vpc"
-}
-
-inputs = {
-  vpc_id = dependency.vpc.outputs.id
-}
-`
-	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
-	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
-
-	// Cursor on the reference (`vpc` in dependency.vpc.outputs.id).
-	locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 23}, tgPath, s.Configs, true)
-	require.Len(t, locs, 2, "label definition + outputs reference")
-}

--- a/internal/tg/references/references_test.go
+++ b/internal/tg/references/references_test.go
@@ -19,46 +19,38 @@ func TestGetReferences(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	commonContent := `locals {
+	content := `locals {
   shared = "value"
-}
-`
-	_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
-	require.NoError(t, err)
-
-	tgContent := `include "common" {
-  path = "common.hcl"
 }
 
 inputs = {
   v = local.shared
 }
 `
-	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
 	require.NoError(t, err)
 
 	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	commonPath := filepath.Join(tmpDir, "common.hcl")
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
-	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
+	s.OpenDocument(t.Context(), l, uri.File(tgPath), content)
 
 	t.Run("includes declaration when requested", func(t *testing.T) {
 		t.Parallel()
 
-		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14}, tgPath, s.Configs, true)
+		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14}, tgPath, true)
 		require.Len(t, locs, 2, "definition + reference")
 
-		// Sorted by file name then position; common.hcl comes first alphabetically.
-		assert.Equal(t, uri.File(commonPath), locs[0].URI)
-		assert.Equal(t, uri.File(tgPath), locs[1].URI)
+		for _, loc := range locs {
+			assert.Equal(t, uri.File(tgPath), loc.URI)
+		}
 	})
 
 	t.Run("excludes declaration when requested", func(t *testing.T) {
 		t.Parallel()
 
-		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14}, tgPath, s.Configs, false)
+		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14}, tgPath, false)
 		require.Len(t, locs, 1, "only the reference, not the definition")
 
 		assert.Equal(t, uri.File(tgPath), locs[0].URI)
@@ -67,7 +59,7 @@ inputs = {
 	t.Run("returns nil for non-renameable position", func(t *testing.T) {
 		t.Parallel()
 
-		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 0}, tgPath, s.Configs, true)
+		locs := references.GetReferences(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 0}, tgPath, true)
 		assert.Nil(t, locs)
 	})
 }

--- a/internal/tg/rename/rename.go
+++ b/internal/tg/rename/rename.go
@@ -2,11 +2,8 @@
 package rename
 
 import (
-	"os"
-	"path/filepath"
 	"regexp"
 	"sort"
-	"strings"
 
 	"terragrunt-ls/internal/ast"
 	"terragrunt-ls/internal/logger"
@@ -43,13 +40,6 @@ type Occurrence struct {
 	File         string
 	Range        protocol.Range
 	IsDefinition bool
-}
-
-// skippedFiles lists base names that are part of the same folder but represent
-// a different file type and should not be scanned for rename occurrences.
-var skippedFiles = map[string]struct{}{
-	"terragrunt.stack.hcl":  {},
-	"terragrunt.values.hcl": {},
 }
 
 // hclIdentifierRE matches a valid HCL identifier (also accepts hyphens, which
@@ -146,53 +136,32 @@ func traversalTarget(expr *hclsyntax.ScopeTraversalExpr, position protocol.Posit
 	}
 }
 
-// FindAllOccurrences returns every rename occurrence of target across all
-// sibling .hcl files in the same directory as originFile (including originFile
-// itself). When a file has an entry in configs with a parsed AST, that AST is
-// used; otherwise the file is read from disk and parsed. Files that fail to
-// read or parse are skipped.
-func FindAllOccurrences(l logger.Logger, target RenameTarget, originFile string, configs map[string]store.Store) []Occurrence {
-	if target.Context == RenameContextNull {
+// FindAllOccurrences returns every occurrence of target within the given file's
+// AST: the declaration site (when present) plus all references. The returned
+// slice is sorted by (line, column) for determinism.
+func FindAllOccurrences(target RenameTarget, file string, st store.Store) []Occurrence {
+	if target.Context == RenameContextNull || st.AST == nil || st.AST.HCLFile == nil {
 		return nil
 	}
 
-	files, err := siblingHCLFiles(filepath.Dir(originFile), configs)
-	if err != nil {
-		l.Error("Failed to list sibling HCL files", "dir", filepath.Dir(originFile), "error", err)
+	body, ok := st.AST.HCLFile.Body.(*hclsyntax.Body)
+	if !ok || body == nil {
 		return nil
 	}
 
-	var occurrences []Occurrence
+	occurrences := definitionOccurrences(target, file, st.AST)
 
-	for _, file := range files {
-		iast := getOrParseAST(file, configs, l)
-		if iast == nil || iast.HCLFile == nil {
-			continue
-		}
-
-		body, ok := iast.HCLFile.Body.(*hclsyntax.Body)
-		if !ok || body == nil {
-			continue
-		}
-
-		occurrences = append(occurrences, definitionOccurrences(target, file, iast)...)
-
-		ast.WalkReferences(body, target.Context, target.Name, func(_ *hclsyntax.ScopeTraversalExpr, r hcl.Range) {
-			occurrences = append(occurrences, Occurrence{
-				File:         file,
-				Range:        ast.FromHCLRange(r),
-				IsDefinition: false,
-			})
+	ast.WalkReferences(body, target.Context, target.Name, func(_ *hclsyntax.ScopeTraversalExpr, r hcl.Range) {
+		occurrences = append(occurrences, Occurrence{
+			File:         file,
+			Range:        ast.FromHCLRange(r),
+			IsDefinition: false,
 		})
-	}
+	})
 
 	// HCL walks attributes in map iteration order, which is non-deterministic.
 	// Sort for stable test output and predictable client-side application.
 	sort.Slice(occurrences, func(i, j int) bool {
-		if occurrences[i].File != occurrences[j].File {
-			return occurrences[i].File < occurrences[j].File
-		}
-
 		if occurrences[i].Range.Start.Line != occurrences[j].Range.Start.Line {
 			return occurrences[i].Range.Start.Line < occurrences[j].Range.Start.Line
 		}
@@ -224,80 +193,6 @@ func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAS
 		Range:        ast.FromHCLRange(attr.NameRange),
 		IsDefinition: true,
 	}}
-}
-
-// siblingHCLFiles returns absolute paths of *.hcl files in dir, excluding
-// stack and values files. Files present in configs (open in the editor but
-// possibly not yet saved to disk) are included even if they don't exist on disk.
-func siblingHCLFiles(dir string, configs map[string]store.Store) ([]string, error) {
-	seen := map[string]struct{}{}
-
-	entries, err := os.ReadDir(dir)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, err
-	}
-
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-
-		name := e.Name()
-		if !isRenameableHCLFile(name) {
-			continue
-		}
-
-		seen[filepath.Join(dir, name)] = struct{}{}
-	}
-
-	for path := range configs {
-		if filepath.Dir(path) != dir {
-			continue
-		}
-
-		if !isRenameableHCLFile(filepath.Base(path)) {
-			continue
-		}
-
-		seen[path] = struct{}{}
-	}
-
-	files := make([]string, 0, len(seen))
-	for f := range seen {
-		files = append(files, f)
-	}
-
-	return files, nil
-}
-
-// isRenameableHCLFile returns true if the base name is a .hcl file that should
-// be scanned for rename occurrences (excludes stack and values files).
-func isRenameableHCLFile(base string) bool {
-	if !strings.HasSuffix(base, ".hcl") {
-		return false
-	}
-
-	_, skip := skippedFiles[base]
-
-	return !skip
-}
-
-// getOrParseAST returns the parsed IndexedAST for path, preferring an
-// already-parsed in-memory AST (so unsaved editor edits are honored).
-func getOrParseAST(path string, configs map[string]store.Store, l logger.Logger) *ast.IndexedAST {
-	if st, ok := configs[path]; ok && st.AST != nil {
-		return st.AST
-	}
-
-	contents, err := os.ReadFile(path)
-	if err != nil {
-		l.Debug("Skipping file (read error)", "file", path, "error", err)
-		return nil
-	}
-
-	iast, _ := ast.ParseHCLFile(path, contents)
-
-	return iast
 }
 
 // rangeContainsPosition reports whether p (LSP coordinates) is inside r (HCL

--- a/internal/tg/rename/rename.go
+++ b/internal/tg/rename/rename.go
@@ -1,0 +1,409 @@
+// Package rename provides the logic for renaming identifiers in Terragrunt configurations.
+package rename
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"terragrunt-ls/internal/ast"
+	"terragrunt-ls/internal/logger"
+	"terragrunt-ls/internal/tg/store"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"go.lsp.dev/protocol"
+)
+
+const (
+	// RenameContextLocal is the context for renaming a local variable
+	// (`locals { name = ... }` and `local.name` references).
+	RenameContextLocal = "local"
+
+	// RenameContextDependency is the context for renaming a dependency block
+	// label (`dependency "name" {}` and `dependency.name.outputs.X` references).
+	RenameContextDependency = "dependency"
+
+	// RenameContextInclude is the context for renaming an include block label
+	// (`include "name" {}` and `include.name.X` references).
+	RenameContextInclude = "include"
+
+	// RenameContextNull means the cursor is not on a renameable identifier.
+	RenameContextNull = "null"
+)
+
+// RenameTarget describes the symbol resolved at the cursor position.
+type RenameTarget struct {
+	// Name is the current identifier value.
+	Name string
+	// Context is one of the RenameContext* constants.
+	Context string
+	// IdentRange is the LSP range covering only the identifier token, suitable
+	// for use as the prepare-rename range. For block labels this excludes the
+	// surrounding quotes.
+	IdentRange protocol.Range
+}
+
+// Occurrence is a single text span (in a specific file) that must be rewritten.
+type Occurrence struct {
+	File  string
+	Range protocol.Range
+}
+
+// skippedFiles lists base names that are part of the same folder but represent
+// a different file type and should not be scanned for rename occurrences.
+var skippedFiles = map[string]struct{}{
+	"terragrunt.stack.hcl":  {},
+	"terragrunt.values.hcl": {},
+}
+
+// hclIdentifierRE matches a valid HCL identifier (also accepts hyphens, which
+// are valid in block labels though not in unquoted variable references).
+var hclIdentifierRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+// IsValidIdentifier reports whether s is a valid HCL identifier.
+func IsValidIdentifier(s string) bool {
+	return hclIdentifierRE.MatchString(s)
+}
+
+// GetRenameTarget identifies the renameable symbol at the given position.
+// Returns a target with Context == RenameContextNull when nothing renameable
+// is at the position.
+func GetRenameTarget(l logger.Logger, st store.Store, position protocol.Position) RenameTarget {
+	null := RenameTarget{Context: RenameContextNull}
+
+	if st.AST == nil {
+		l.Debug("No AST found for rename")
+		return null
+	}
+
+	inode := st.AST.FindNodeAt(ast.ToHCLPos(position))
+	if inode == nil {
+		l.Debug("No node at position", "line", position.Line, "character", position.Character)
+		return null
+	}
+
+	if expr, ok := inode.Node.(*hclsyntax.ScopeTraversalExpr); ok {
+		return traversalTarget(expr, position)
+	}
+
+	for cur := inode; cur != nil; cur = cur.Parent {
+		switch n := cur.Node.(type) {
+		case *hclsyntax.Block:
+			if t, ok := blockLabelTarget(n, position); ok {
+				return t
+			}
+			// We hit an enclosing block but the cursor isn't on its label.
+			return null
+
+		case *hclsyntax.Attribute:
+			if !ast.IsLocalAttribute(cur) {
+				return null
+			}
+
+			if !rangeContainsPosition(n.NameRange, position) {
+				return null
+			}
+
+			return RenameTarget{
+				Name:       n.Name,
+				Context:    RenameContextLocal,
+				IdentRange: ast.FromHCLRange(n.NameRange),
+			}
+		}
+	}
+
+	return null
+}
+
+// traversalTarget extracts a RenameTarget from a ScopeTraversalExpr if the
+// cursor is positioned on its first two traversal steps and the root is a
+// supported kind.
+func traversalTarget(expr *hclsyntax.ScopeTraversalExpr, position protocol.Position) RenameTarget {
+	null := RenameTarget{Context: RenameContextNull}
+
+	if len(expr.Traversal) < ast.MinReferenceTraversalLen {
+		return null
+	}
+
+	rootStep, ok := expr.Traversal[0].(hcl.TraverseRoot)
+	if !ok {
+		return null
+	}
+
+	attrStep, ok := expr.Traversal[1].(hcl.TraverseAttr)
+	if !ok {
+		return null
+	}
+
+	// Restrict cursor to the first two steps so that, e.g., `dependency.vpc.outputs.x`
+	// only triggers rename when the cursor is on `dependency` or `vpc`.
+	firstTwo := hcl.Range{
+		Filename: rootStep.SrcRange.Filename,
+		Start:    rootStep.SrcRange.Start,
+		End:      attrStep.SrcRange.End,
+	}
+	if !rangeContainsPosition(firstTwo, position) {
+		return null
+	}
+
+	context, ok := contextForRoot(rootStep.Name)
+	if !ok {
+		return null
+	}
+
+	return RenameTarget{
+		Name:       attrStep.Name,
+		Context:    context,
+		IdentRange: ast.FromHCLRange(ast.TraverseAttrIdentRange(attrStep)),
+	}
+}
+
+// blockLabelTarget returns a RenameTarget when the cursor is on the first
+// label of an `include` or `dependency` block.
+func blockLabelTarget(block *hclsyntax.Block, position protocol.Position) (RenameTarget, bool) {
+	null := RenameTarget{Context: RenameContextNull}
+
+	context, ok := contextForRoot(block.Type)
+	if !ok || context == RenameContextLocal {
+		return null, false
+	}
+
+	if len(block.Labels) == 0 || len(block.LabelRanges) == 0 {
+		return null, false
+	}
+
+	if !rangeContainsPosition(block.LabelRanges[0], position) {
+		return null, false
+	}
+
+	return RenameTarget{
+		Name:       block.Labels[0],
+		Context:    context,
+		IdentRange: labelInnerRange(block.LabelRanges[0]),
+	}, true
+}
+
+// contextForRoot maps an HCL root identifier (the first traversal step or a
+// block type) to a rename context. Returns false for unsupported names.
+func contextForRoot(name string) (string, bool) {
+	switch name {
+	case "local":
+		return RenameContextLocal, true
+	case "include":
+		return RenameContextInclude, true
+	case "dependency":
+		return RenameContextDependency, true
+	}
+
+	return "", false
+}
+
+// FindAllOccurrences returns every rename occurrence of target across all
+// sibling .hcl files in the same directory as originFile (including originFile
+// itself). When a file has an entry in configs with a parsed AST, that AST is
+// used; otherwise the file is read from disk and parsed. Files that fail to
+// read or parse are skipped.
+func FindAllOccurrences(l logger.Logger, target RenameTarget, originFile string, configs map[string]store.Store) []Occurrence {
+	if target.Context == RenameContextNull {
+		return nil
+	}
+
+	files, err := siblingHCLFiles(filepath.Dir(originFile), configs)
+	if err != nil {
+		l.Error("Failed to list sibling HCL files", "dir", filepath.Dir(originFile), "error", err)
+		return nil
+	}
+
+	var occurrences []Occurrence
+
+	for _, file := range files {
+		iast := getOrParseAST(file, configs, l)
+		if iast == nil || iast.HCLFile == nil {
+			continue
+		}
+
+		body, ok := iast.HCLFile.Body.(*hclsyntax.Body)
+		if !ok || body == nil {
+			continue
+		}
+
+		occurrences = append(occurrences, definitionOccurrences(target, file, iast, body)...)
+
+		ast.WalkReferences(body, target.Context, target.Name, func(_ *hclsyntax.ScopeTraversalExpr, r hcl.Range) {
+			occurrences = append(occurrences, Occurrence{
+				File:  file,
+				Range: ast.FromHCLRange(r),
+			})
+		})
+	}
+
+	// HCL walks attributes in map iteration order, which is non-deterministic.
+	// Sort for stable test output and predictable client-side application.
+	sort.Slice(occurrences, func(i, j int) bool {
+		if occurrences[i].File != occurrences[j].File {
+			return occurrences[i].File < occurrences[j].File
+		}
+
+		if occurrences[i].Range.Start.Line != occurrences[j].Range.Start.Line {
+			return occurrences[i].Range.Start.Line < occurrences[j].Range.Start.Line
+		}
+
+		return occurrences[i].Range.Start.Character < occurrences[j].Range.Start.Character
+	})
+
+	return occurrences
+}
+
+// definitionOccurrences finds the definition site(s) of target in the given file.
+func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAST, body *hclsyntax.Body) []Occurrence {
+	var occs []Occurrence
+
+	switch target.Context {
+	case RenameContextLocal:
+		def, ok := iast.Locals[target.Name]
+		if !ok {
+			return nil
+		}
+
+		attr, ok := def.Node.(*hclsyntax.Attribute)
+		if !ok {
+			return nil
+		}
+
+		occs = append(occs, Occurrence{
+			File:  file,
+			Range: ast.FromHCLRange(attr.NameRange),
+		})
+
+	case RenameContextInclude, RenameContextDependency:
+		for _, blk := range body.Blocks {
+			if blk.Type != target.Context {
+				continue
+			}
+
+			if len(blk.Labels) == 0 || blk.Labels[0] != target.Name {
+				continue
+			}
+
+			if len(blk.LabelRanges) == 0 {
+				continue
+			}
+
+			occs = append(occs, Occurrence{
+				File:  file,
+				Range: labelInnerRange(blk.LabelRanges[0]),
+			})
+		}
+	}
+
+	return occs
+}
+
+// siblingHCLFiles returns absolute paths of *.hcl files in dir, excluding
+// stack and values files. Files present in configs (open in the editor but
+// possibly not yet saved to disk) are included even if they don't exist on disk.
+func siblingHCLFiles(dir string, configs map[string]store.Store) ([]string, error) {
+	seen := map[string]struct{}{}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+
+		name := e.Name()
+		if !isRenameableHCLFile(name) {
+			continue
+		}
+
+		seen[filepath.Join(dir, name)] = struct{}{}
+	}
+
+	for path := range configs {
+		if filepath.Dir(path) != dir {
+			continue
+		}
+
+		if !isRenameableHCLFile(filepath.Base(path)) {
+			continue
+		}
+
+		seen[path] = struct{}{}
+	}
+
+	files := make([]string, 0, len(seen))
+	for f := range seen {
+		files = append(files, f)
+	}
+
+	return files, nil
+}
+
+// isRenameableHCLFile returns true if the base name is a .hcl file that should
+// be scanned for rename occurrences (excludes stack and values files).
+func isRenameableHCLFile(base string) bool {
+	if !strings.HasSuffix(base, ".hcl") {
+		return false
+	}
+
+	_, skip := skippedFiles[base]
+
+	return !skip
+}
+
+// getOrParseAST returns the parsed IndexedAST for path, preferring an
+// already-parsed in-memory AST (so unsaved editor edits are honored).
+func getOrParseAST(path string, configs map[string]store.Store, l logger.Logger) *ast.IndexedAST {
+	if st, ok := configs[path]; ok && st.AST != nil {
+		return st.AST
+	}
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		l.Debug("Skipping file (read error)", "file", path, "error", err)
+		return nil
+	}
+
+	iast, _ := ast.ParseHCLFile(path, contents)
+
+	return iast
+}
+
+// labelInnerRange returns the LSP range of a quoted label's contents, excluding
+// the surrounding double quotes.
+func labelInnerRange(r hcl.Range) protocol.Range {
+	r.Start.Column++
+	r.Start.Byte++
+	r.End.Column--
+	r.End.Byte--
+
+	return ast.FromHCLRange(r)
+}
+
+// rangeContainsPosition reports whether p (LSP coordinates) is inside r (HCL
+// coordinates). The end of an HCL range is exclusive.
+func rangeContainsPosition(r hcl.Range, p protocol.Position) bool {
+	line := int(p.Line) + 1
+	col := int(p.Character) + 1
+
+	if line < r.Start.Line || line > r.End.Line {
+		return false
+	}
+
+	if line == r.Start.Line && col < r.Start.Column {
+		return false
+	}
+
+	if line == r.End.Line && col >= r.End.Column {
+		return false
+	}
+
+	return true
+}

--- a/internal/tg/rename/rename.go
+++ b/internal/tg/rename/rename.go
@@ -22,10 +22,6 @@ const (
 	// (`locals { name = ... }` and `local.name` references).
 	RenameContextLocal = "local"
 
-	// RenameContextDependency is the context for renaming a dependency block
-	// label (`dependency "name" {}` and `dependency.name.outputs.X` references).
-	RenameContextDependency = "dependency"
-
 	// RenameContextNull means the cursor is not on a renameable identifier.
 	RenameContextNull = "null"
 )
@@ -37,8 +33,7 @@ type RenameTarget struct {
 	// Context is one of the RenameContext* constants.
 	Context string
 	// IdentRange is the LSP range covering only the identifier token, suitable
-	// for use as the prepare-rename range. For block labels this excludes the
-	// surrounding quotes.
+	// for use as the prepare-rename range.
 	IdentRange protocol.Range
 }
 
@@ -88,28 +83,23 @@ func GetRenameTarget(l logger.Logger, st store.Store, position protocol.Position
 	}
 
 	for cur := inode; cur != nil; cur = cur.Parent {
-		switch n := cur.Node.(type) {
-		case *hclsyntax.Block:
-			if t, ok := blockLabelTarget(n, position); ok {
-				return t
-			}
-			// We hit an enclosing block but the cursor isn't on its label.
+		attr, ok := cur.Node.(*hclsyntax.Attribute)
+		if !ok {
+			continue
+		}
+
+		if !ast.IsLocalAttribute(cur) {
 			return null
+		}
 
-		case *hclsyntax.Attribute:
-			if !ast.IsLocalAttribute(cur) {
-				return null
-			}
+		if !rangeContainsPosition(attr.NameRange, position) {
+			return null
+		}
 
-			if !rangeContainsPosition(n.NameRange, position) {
-				return null
-			}
-
-			return RenameTarget{
-				Name:       n.Name,
-				Context:    RenameContextLocal,
-				IdentRange: ast.FromHCLRange(n.NameRange),
-			}
+		return RenameTarget{
+			Name:       attr.Name,
+			Context:    RenameContextLocal,
+			IdentRange: ast.FromHCLRange(attr.NameRange),
 		}
 	}
 
@@ -117,8 +107,7 @@ func GetRenameTarget(l logger.Logger, st store.Store, position protocol.Position
 }
 
 // traversalTarget extracts a RenameTarget from a ScopeTraversalExpr if the
-// cursor is positioned on its first two traversal steps and the root is a
-// supported kind.
+// cursor is positioned on its first two traversal steps and the root is `local`.
 func traversalTarget(expr *hclsyntax.ScopeTraversalExpr, position protocol.Position) RenameTarget {
 	null := RenameTarget{Context: RenameContextNull}
 
@@ -136,8 +125,11 @@ func traversalTarget(expr *hclsyntax.ScopeTraversalExpr, position protocol.Posit
 		return null
 	}
 
-	// Restrict cursor to the first two steps so that, e.g., `dependency.vpc.outputs.x`
-	// only triggers rename when the cursor is on `dependency` or `vpc`.
+	if rootStep.Name != "local" {
+		return null
+	}
+
+	// Restrict cursor to the first two steps.
 	firstTwo := hcl.Range{
 		Filename: rootStep.SrcRange.Filename,
 		Start:    rootStep.SrcRange.Start,
@@ -147,54 +139,11 @@ func traversalTarget(expr *hclsyntax.ScopeTraversalExpr, position protocol.Posit
 		return null
 	}
 
-	context, ok := contextForRoot(rootStep.Name)
-	if !ok {
-		return null
-	}
-
 	return RenameTarget{
 		Name:       attrStep.Name,
-		Context:    context,
+		Context:    RenameContextLocal,
 		IdentRange: ast.FromHCLRange(ast.TraverseAttrIdentRange(attrStep)),
 	}
-}
-
-// blockLabelTarget returns a RenameTarget when the cursor is on the first
-// label of an `include` or `dependency` block.
-func blockLabelTarget(block *hclsyntax.Block, position protocol.Position) (RenameTarget, bool) {
-	null := RenameTarget{Context: RenameContextNull}
-
-	context, ok := contextForRoot(block.Type)
-	if !ok || context == RenameContextLocal {
-		return null, false
-	}
-
-	if len(block.Labels) == 0 || len(block.LabelRanges) == 0 {
-		return null, false
-	}
-
-	if !rangeContainsPosition(block.LabelRanges[0], position) {
-		return null, false
-	}
-
-	return RenameTarget{
-		Name:       block.Labels[0],
-		Context:    context,
-		IdentRange: labelInnerRange(block.LabelRanges[0]),
-	}, true
-}
-
-// contextForRoot maps an HCL root identifier (the first traversal step or a
-// block type) to a rename context. Returns false for unsupported names.
-func contextForRoot(name string) (string, bool) {
-	switch name {
-	case "local":
-		return RenameContextLocal, true
-	case "dependency":
-		return RenameContextDependency, true
-	}
-
-	return "", false
 }
 
 // FindAllOccurrences returns every rename occurrence of target across all
@@ -226,7 +175,7 @@ func FindAllOccurrences(l logger.Logger, target RenameTarget, originFile string,
 			continue
 		}
 
-		occurrences = append(occurrences, definitionOccurrences(target, file, iast, body)...)
+		occurrences = append(occurrences, definitionOccurrences(target, file, iast)...)
 
 		ast.WalkReferences(body, target.Context, target.Name, func(_ *hclsyntax.ScopeTraversalExpr, r hcl.Range) {
 			occurrences = append(occurrences, Occurrence{
@@ -255,50 +204,26 @@ func FindAllOccurrences(l logger.Logger, target RenameTarget, originFile string,
 }
 
 // definitionOccurrences finds the definition site(s) of target in the given file.
-func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAST, body *hclsyntax.Body) []Occurrence {
-	var occs []Occurrence
-
-	switch target.Context {
-	case RenameContextLocal:
-		def, ok := iast.Locals[target.Name]
-		if !ok {
-			return nil
-		}
-
-		attr, ok := def.Node.(*hclsyntax.Attribute)
-		if !ok {
-			return nil
-		}
-
-		occs = append(occs, Occurrence{
-			File:         file,
-			Range:        ast.FromHCLRange(attr.NameRange),
-			IsDefinition: true,
-		})
-
-	case RenameContextDependency:
-		for _, blk := range body.Blocks {
-			if blk.Type != target.Context {
-				continue
-			}
-
-			if len(blk.Labels) == 0 || blk.Labels[0] != target.Name {
-				continue
-			}
-
-			if len(blk.LabelRanges) == 0 {
-				continue
-			}
-
-			occs = append(occs, Occurrence{
-				File:         file,
-				Range:        labelInnerRange(blk.LabelRanges[0]),
-				IsDefinition: true,
-			})
-		}
+func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAST) []Occurrence {
+	if target.Context != RenameContextLocal {
+		return nil
 	}
 
-	return occs
+	def, ok := iast.Locals[target.Name]
+	if !ok {
+		return nil
+	}
+
+	attr, ok := def.Node.(*hclsyntax.Attribute)
+	if !ok {
+		return nil
+	}
+
+	return []Occurrence{{
+		File:         file,
+		Range:        ast.FromHCLRange(attr.NameRange),
+		IsDefinition: true,
+	}}
 }
 
 // siblingHCLFiles returns absolute paths of *.hcl files in dir, excluding
@@ -373,17 +298,6 @@ func getOrParseAST(path string, configs map[string]store.Store, l logger.Logger)
 	iast, _ := ast.ParseHCLFile(path, contents)
 
 	return iast
-}
-
-// labelInnerRange returns the LSP range of a quoted label's contents, excluding
-// the surrounding double quotes.
-func labelInnerRange(r hcl.Range) protocol.Range {
-	r.Start.Column++
-	r.Start.Byte++
-	r.End.Column--
-	r.End.Byte--
-
-	return ast.FromHCLRange(r)
 }
 
 // rangeContainsPosition reports whether p (LSP coordinates) is inside r (HCL

--- a/internal/tg/rename/rename.go
+++ b/internal/tg/rename/rename.go
@@ -26,10 +26,6 @@ const (
 	// label (`dependency "name" {}` and `dependency.name.outputs.X` references).
 	RenameContextDependency = "dependency"
 
-	// RenameContextInclude is the context for renaming an include block label
-	// (`include "name" {}` and `include.name.X` references).
-	RenameContextInclude = "include"
-
 	// RenameContextNull means the cursor is not on a renameable identifier.
 	RenameContextNull = "null"
 )
@@ -194,8 +190,6 @@ func contextForRoot(name string) (string, bool) {
 	switch name {
 	case "local":
 		return RenameContextLocal, true
-	case "include":
-		return RenameContextInclude, true
 	case "dependency":
 		return RenameContextDependency, true
 	}
@@ -282,7 +276,7 @@ func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAS
 			IsDefinition: true,
 		})
 
-	case RenameContextInclude, RenameContextDependency:
+	case RenameContextDependency:
 		for _, blk := range body.Blocks {
 			if blk.Type != target.Context {
 				continue

--- a/internal/tg/rename/rename.go
+++ b/internal/tg/rename/rename.go
@@ -46,10 +46,12 @@ type RenameTarget struct {
 	IdentRange protocol.Range
 }
 
-// Occurrence is a single text span (in a specific file) that must be rewritten.
+// Occurrence is a single text span (in a specific file) of the target symbol.
+// IsDefinition is true for the symbol's declaration site, false for references.
 type Occurrence struct {
-	File  string
-	Range protocol.Range
+	File         string
+	Range        protocol.Range
+	IsDefinition bool
 }
 
 // skippedFiles lists base names that are part of the same folder but represent
@@ -234,8 +236,9 @@ func FindAllOccurrences(l logger.Logger, target RenameTarget, originFile string,
 
 		ast.WalkReferences(body, target.Context, target.Name, func(_ *hclsyntax.ScopeTraversalExpr, r hcl.Range) {
 			occurrences = append(occurrences, Occurrence{
-				File:  file,
-				Range: ast.FromHCLRange(r),
+				File:         file,
+				Range:        ast.FromHCLRange(r),
+				IsDefinition: false,
 			})
 		})
 	}
@@ -274,8 +277,9 @@ func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAS
 		}
 
 		occs = append(occs, Occurrence{
-			File:  file,
-			Range: ast.FromHCLRange(attr.NameRange),
+			File:         file,
+			Range:        ast.FromHCLRange(attr.NameRange),
+			IsDefinition: true,
 		})
 
 	case RenameContextInclude, RenameContextDependency:
@@ -293,8 +297,9 @@ func definitionOccurrences(target RenameTarget, file string, iast *ast.IndexedAS
 			}
 
 			occs = append(occs, Occurrence{
-				File:  file,
-				Range: labelInnerRange(blk.LabelRanges[0]),
+				File:         file,
+				Range:        labelInnerRange(blk.LabelRanges[0]),
+				IsDefinition: true,
 			})
 		}
 	}

--- a/internal/tg/rename/rename_test.go
+++ b/internal/tg/rename/rename_test.go
@@ -1,0 +1,383 @@
+package rename_test
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"terragrunt-ls/internal/testutils"
+	"terragrunt-ls/internal/tg"
+	"terragrunt-ls/internal/tg/rename"
+	"terragrunt-ls/internal/tg/store"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+)
+
+func TestIsValidIdentifier(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name string
+		want bool
+	}{
+		{"foo", true},
+		{"_bar", true},
+		{"my_local", true},
+		{"a1", true},
+		{"my-include", true},
+		{"", false},
+		{"1foo", false},
+		{"foo bar", false},
+		{"foo.bar", false},
+		{"local.foo", false},
+		{"foo!", false},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, rename.IsValidIdentifier(tt.name))
+		})
+	}
+}
+
+func TestGetRenameTarget(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name            string
+		document        string
+		expectedName    string
+		expectedContext string
+		position        protocol.Position
+	}{
+		{
+			name:            "empty document",
+			document:        "",
+			position:        protocol.Position{Line: 0, Character: 0},
+			expectedContext: rename.RenameContextNull,
+		},
+		{
+			name: "cursor on local definition",
+			document: `locals {
+  foo = "bar"
+}`,
+			position:        protocol.Position{Line: 1, Character: 3},
+			expectedName:    "foo",
+			expectedContext: rename.RenameContextLocal,
+		},
+		{
+			name: "cursor on local reference",
+			document: `locals {
+  foo = "bar"
+}
+inputs = {
+  v = local.foo
+}`,
+			position:        protocol.Position{Line: 4, Character: 14},
+			expectedName:    "foo",
+			expectedContext: rename.RenameContextLocal,
+		},
+		{
+			name:            "cursor on local keyword in reference",
+			document:        `inputs = { v = local.foo }`,
+			position:        protocol.Position{Line: 0, Character: 16},
+			expectedName:    "foo",
+			expectedContext: rename.RenameContextLocal,
+		},
+		{
+			name: "cursor on include label",
+			document: `include "root" {
+  path = "root.hcl"
+}`,
+			position:        protocol.Position{Line: 0, Character: 10},
+			expectedName:    "root",
+			expectedContext: rename.RenameContextInclude,
+		},
+		{
+			name: "cursor on dependency label",
+			document: `dependency "vpc" {
+  config_path = "../vpc"
+}`,
+			position:        protocol.Position{Line: 0, Character: 13},
+			expectedName:    "vpc",
+			expectedContext: rename.RenameContextDependency,
+		},
+		{
+			name: "cursor on dependency outputs reference",
+			document: `inputs = {
+  id = dependency.vpc.outputs.id
+}`,
+			position:        protocol.Position{Line: 1, Character: 19},
+			expectedName:    "vpc",
+			expectedContext: rename.RenameContextDependency,
+		},
+		{
+			name: "cursor on outputs step is not renameable",
+			document: `inputs = {
+  id = dependency.vpc.outputs.id
+}`,
+			position:        protocol.Position{Line: 1, Character: 24},
+			expectedContext: rename.RenameContextNull,
+		},
+		{
+			name: "cursor on unrelated traversal root",
+			document: `inputs = {
+  v = path.module
+}`,
+			position:        protocol.Position{Line: 1, Character: 8},
+			expectedContext: rename.RenameContextNull,
+		},
+		{
+			name: "cursor on locals block keyword",
+			document: `locals {
+  foo = "bar"
+}`,
+			position:        protocol.Position{Line: 0, Character: 3},
+			expectedContext: rename.RenameContextNull,
+		},
+		{
+			name: "cursor on whitespace",
+			document: `locals {
+  foo = "bar"
+}`,
+			position:        protocol.Position{Line: 1, Character: 0},
+			expectedContext: rename.RenameContextNull,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := testutils.NewTestLogger(t)
+			s := tg.NewState()
+
+			docURI := uri.File("/test/terragrunt.hcl")
+			s.OpenDocument(context.Background(), l, docURI, tt.document)
+
+			target := rename.GetRenameTarget(l, s.Configs[docURI.Filename()], tt.position)
+
+			assert.Equal(t, tt.expectedContext, target.Context)
+			if tt.expectedContext != rename.RenameContextNull {
+				assert.Equal(t, tt.expectedName, target.Name)
+			}
+		})
+	}
+}
+
+func TestFindAllOccurrences_LocalSingleFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	hclPath := filepath.Join(tmpDir, "terragrunt.hcl")
+
+	content := `locals {
+  foo = "bar"
+}
+
+dependency "a" {
+  config_path = local.foo
+}
+
+dependency "b" {
+  config_path = local.foo
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	docURI := uri.File(hclPath)
+	s.OpenDocument(context.Background(), l, docURI, content)
+
+	target := rename.GetRenameTarget(l, s.Configs[hclPath], protocol.Position{Line: 1, Character: 3})
+	require.Equal(t, rename.RenameContextLocal, target.Context)
+	require.Equal(t, "foo", target.Name)
+
+	occs := rename.FindAllOccurrences(l, target, hclPath, s.Configs)
+	require.Len(t, occs, 3)
+
+	for _, occ := range occs {
+		assert.Equal(t, hclPath, occ.File)
+	}
+}
+
+func TestFindAllOccurrences_LocalCrossFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	commonContent := `locals {
+  shared = "value"
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
+	require.NoError(t, err)
+
+	tgContent := `include "common" {
+  path = "common.hcl"
+}
+
+inputs = {
+  v = local.shared
+}
+`
+	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	commonPath := filepath.Join(tmpDir, "common.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+
+	// Open only terragrunt.hcl in the editor; common.hcl stays on disk only.
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+
+	// Cursor on the local.shared reference.
+	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14})
+	require.Equal(t, rename.RenameContextLocal, target.Context)
+	require.Equal(t, "shared", target.Name)
+
+	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
+	require.Len(t, occs, 2)
+
+	files := []string{occs[0].File, occs[1].File}
+	sort.Strings(files)
+	assert.Equal(t, []string{commonPath, tgPath}, files)
+}
+
+func TestFindAllOccurrences_SkipsStackAndValues(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	mainContent := `locals { foo = "v" }
+inputs = { v = local.foo }
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", mainContent)
+	require.NoError(t, err)
+
+	// These would parse but should not be scanned.
+	_, err = testutils.CreateFile(tmpDir, "terragrunt.stack.hcl", `unit "x" { source = "./x" path = "x" }`)
+	require.NoError(t, err)
+	_, err = testutils.CreateFile(tmpDir, "terragrunt.values.hcl", `foo = "shadow"`)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), mainContent)
+
+	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 9})
+	require.Equal(t, rename.RenameContextLocal, target.Context)
+
+	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
+	for _, occ := range occs {
+		assert.Equal(t, "terragrunt.hcl", filepath.Base(occ.File), "must not include stack/values files")
+	}
+}
+
+func TestFindAllOccurrences_PrefersInMemoryAST(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// On disk: defines a different name.
+	diskContent := `locals { other = "v" }`
+	_, err := testutils.CreateFile(tmpDir, "common.hcl", diskContent)
+	require.NoError(t, err)
+
+	tgContent := `inputs = { v = local.shared }`
+	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	commonPath := filepath.Join(tmpDir, "common.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+
+	// Open both files; for common.hcl provide an in-memory version that
+	// matches the local name `shared`.
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+	s.OpenDocument(context.Background(), l, uri.File(commonPath), `locals { shared = "v" }`)
+
+	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 22})
+	require.Equal(t, rename.RenameContextLocal, target.Context)
+
+	configs := map[string]store.Store{
+		tgPath:     s.Configs[tgPath],
+		commonPath: s.Configs[commonPath],
+	}
+
+	occs := rename.FindAllOccurrences(l, target, tgPath, configs)
+	require.Len(t, occs, 2, "definition (from in-memory common) + reference")
+}
+
+func TestFindAllOccurrences_DependencyLabel(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	content := `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.id
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
+
+	// Cursor on the dependency label "vpc".
+	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 13})
+	require.Equal(t, rename.RenameContextDependency, target.Context)
+	require.Equal(t, "vpc", target.Name)
+
+	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
+	require.Len(t, occs, 2, "definition label + outputs reference")
+}
+
+func TestFindAllOccurrences_IncludeLabel(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	content := `include "root" {
+  path = "root.hcl"
+}
+
+inputs = {
+  region = include.root.locals.region
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
+
+	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 10})
+	require.Equal(t, rename.RenameContextInclude, target.Context)
+	require.Equal(t, "root", target.Name)
+
+	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
+	require.Len(t, occs, 2, "definition label + include.root.* reference")
+}

--- a/internal/tg/rename/rename_test.go
+++ b/internal/tg/rename/rename_test.go
@@ -89,32 +89,6 @@ inputs = {
 			expectedContext: rename.RenameContextLocal,
 		},
 		{
-			name: "cursor on dependency label",
-			document: `dependency "vpc" {
-  config_path = "../vpc"
-}`,
-			position:        protocol.Position{Line: 0, Character: 13},
-			expectedName:    "vpc",
-			expectedContext: rename.RenameContextDependency,
-		},
-		{
-			name: "cursor on dependency outputs reference",
-			document: `inputs = {
-  id = dependency.vpc.outputs.id
-}`,
-			position:        protocol.Position{Line: 1, Character: 19},
-			expectedName:    "vpc",
-			expectedContext: rename.RenameContextDependency,
-		},
-		{
-			name: "cursor on outputs step is not renameable",
-			document: `inputs = {
-  id = dependency.vpc.outputs.id
-}`,
-			position:        protocol.Position{Line: 1, Character: 24},
-			expectedContext: rename.RenameContextNull,
-		},
-		{
 			name: "cursor on unrelated traversal root",
 			document: `inputs = {
   v = path.module
@@ -310,35 +284,4 @@ func TestFindAllOccurrences_PrefersInMemoryAST(t *testing.T) {
 
 	occs := rename.FindAllOccurrences(l, target, tgPath, configs)
 	require.Len(t, occs, 2, "definition (from in-memory common) + reference")
-}
-
-func TestFindAllOccurrences_DependencyLabel(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	content := `dependency "vpc" {
-  config_path = "../vpc"
-}
-
-inputs = {
-  vpc_id = dependency.vpc.outputs.id
-}
-`
-	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
-	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
-
-	// Cursor on the dependency label "vpc".
-	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 13})
-	require.Equal(t, rename.RenameContextDependency, target.Context)
-	require.Equal(t, "vpc", target.Name)
-
-	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
-	require.Len(t, occs, 2, "definition label + outputs reference")
 }

--- a/internal/tg/rename/rename_test.go
+++ b/internal/tg/rename/rename_test.go
@@ -1,7 +1,6 @@
 package rename_test
 
 import (
-	"context"
 	"path/filepath"
 	"sort"
 	"terragrunt-ls/internal/testutils"
@@ -122,7 +121,7 @@ inputs = {
 			s := tg.NewState()
 
 			docURI := uri.File("/test/terragrunt.hcl")
-			s.OpenDocument(context.Background(), l, docURI, tt.document)
+			s.OpenDocument(t.Context(), l, docURI, tt.document)
 
 			target := rename.GetRenameTarget(l, s.Configs[docURI.Filename()], tt.position)
 
@@ -158,7 +157,7 @@ dependency "b" {
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
 	docURI := uri.File(hclPath)
-	s.OpenDocument(context.Background(), l, docURI, content)
+	s.OpenDocument(t.Context(), l, docURI, content)
 
 	target := rename.GetRenameTarget(l, s.Configs[hclPath], protocol.Position{Line: 1, Character: 3})
 	require.Equal(t, rename.RenameContextLocal, target.Context)
@@ -202,7 +201,7 @@ inputs = {
 	s := tg.NewState()
 
 	// Open only terragrunt.hcl in the editor; common.hcl stays on disk only.
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
 
 	// Cursor on the local.shared reference.
 	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14})
@@ -238,7 +237,7 @@ inputs = { v = local.foo }
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), mainContent)
+	s.OpenDocument(t.Context(), l, uri.File(tgPath), mainContent)
 
 	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 9})
 	require.Equal(t, rename.RenameContextLocal, target.Context)
@@ -271,8 +270,8 @@ func TestFindAllOccurrences_PrefersInMemoryAST(t *testing.T) {
 
 	// Open both files; for common.hcl provide an in-memory version that
 	// matches the local name `shared`.
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
-	s.OpenDocument(context.Background(), l, uri.File(commonPath), `locals { shared = "v" }`)
+	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
+	s.OpenDocument(t.Context(), l, uri.File(commonPath), `locals { shared = "v" }`)
 
 	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 22})
 	require.Equal(t, rename.RenameContextLocal, target.Context)

--- a/internal/tg/rename/rename_test.go
+++ b/internal/tg/rename/rename_test.go
@@ -2,11 +2,9 @@ package rename_test
 
 import (
 	"path/filepath"
-	"sort"
 	"terragrunt-ls/internal/testutils"
 	"terragrunt-ls/internal/tg"
 	"terragrunt-ls/internal/tg/rename"
-	"terragrunt-ls/internal/tg/store"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,7 +131,7 @@ inputs = {
 	}
 }
 
-func TestFindAllOccurrences_LocalSingleFile(t *testing.T) {
+func TestFindAllOccurrences_Local(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
@@ -159,128 +157,54 @@ dependency "b" {
 	docURI := uri.File(hclPath)
 	s.OpenDocument(t.Context(), l, docURI, content)
 
-	target := rename.GetRenameTarget(l, s.Configs[hclPath], protocol.Position{Line: 1, Character: 3})
+	st := s.Configs[hclPath]
+
+	target := rename.GetRenameTarget(l, st, protocol.Position{Line: 1, Character: 3})
 	require.Equal(t, rename.RenameContextLocal, target.Context)
 	require.Equal(t, "foo", target.Name)
 
-	occs := rename.FindAllOccurrences(l, target, hclPath, s.Configs)
+	occs := rename.FindAllOccurrences(target, hclPath, st)
 	require.Len(t, occs, 3)
+
+	var defs int
 
 	for _, occ := range occs {
 		assert.Equal(t, hclPath, occ.File)
+
+		if occ.IsDefinition {
+			defs++
+		}
 	}
+
+	assert.Equal(t, 1, defs, "exactly one definition occurrence")
 }
 
-func TestFindAllOccurrences_LocalCrossFile(t *testing.T) {
+func TestFindAllOccurrences_NoDefinition(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
+	hclPath := filepath.Join(tmpDir, "terragrunt.hcl")
 
-	commonContent := `locals {
-  shared = "value"
-}
-`
-	_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
-	require.NoError(t, err)
-
-	tgContent := `include "common" {
-  path = "common.hcl"
-}
-
-inputs = {
+	// References to a local that has no declaration in this file.
+	content := `inputs = {
   v = local.shared
 }
 `
-	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
 	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	commonPath := filepath.Join(tmpDir, "common.hcl")
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
+	docURI := uri.File(hclPath)
+	s.OpenDocument(t.Context(), l, docURI, content)
 
-	// Open only terragrunt.hcl in the editor; common.hcl stays on disk only.
-	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
+	st := s.Configs[hclPath]
 
-	// Cursor on the local.shared reference.
-	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 5, Character: 14})
+	target := rename.GetRenameTarget(l, st, protocol.Position{Line: 1, Character: 14})
 	require.Equal(t, rename.RenameContextLocal, target.Context)
 	require.Equal(t, "shared", target.Name)
 
-	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
-	require.Len(t, occs, 2)
-
-	files := []string{occs[0].File, occs[1].File}
-	sort.Strings(files)
-	assert.Equal(t, []string{commonPath, tgPath}, files)
-}
-
-func TestFindAllOccurrences_SkipsStackAndValues(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	mainContent := `locals { foo = "v" }
-inputs = { v = local.foo }
-`
-	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", mainContent)
-	require.NoError(t, err)
-
-	// These would parse but should not be scanned.
-	_, err = testutils.CreateFile(tmpDir, "terragrunt.stack.hcl", `unit "x" { source = "./x" path = "x" }`)
-	require.NoError(t, err)
-	_, err = testutils.CreateFile(tmpDir, "terragrunt.values.hcl", `foo = "shadow"`)
-	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-	s.OpenDocument(t.Context(), l, uri.File(tgPath), mainContent)
-
-	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 9})
-	require.Equal(t, rename.RenameContextLocal, target.Context)
-
-	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
-	for _, occ := range occs {
-		assert.Equal(t, "terragrunt.hcl", filepath.Base(occ.File), "must not include stack/values files")
-	}
-}
-
-func TestFindAllOccurrences_PrefersInMemoryAST(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	// On disk: defines a different name.
-	diskContent := `locals { other = "v" }`
-	_, err := testutils.CreateFile(tmpDir, "common.hcl", diskContent)
-	require.NoError(t, err)
-
-	tgContent := `inputs = { v = local.shared }`
-	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
-	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	commonPath := filepath.Join(tmpDir, "common.hcl")
-
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-
-	// Open both files; for common.hcl provide an in-memory version that
-	// matches the local name `shared`.
-	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
-	s.OpenDocument(t.Context(), l, uri.File(commonPath), `locals { shared = "v" }`)
-
-	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 22})
-	require.Equal(t, rename.RenameContextLocal, target.Context)
-
-	configs := map[string]store.Store{
-		tgPath:     s.Configs[tgPath],
-		commonPath: s.Configs[commonPath],
-	}
-
-	occs := rename.FindAllOccurrences(l, target, tgPath, configs)
-	require.Len(t, occs, 2, "definition (from in-memory common) + reference")
+	occs := rename.FindAllOccurrences(target, hclPath, st)
+	require.Len(t, occs, 1, "only the reference, no declaration in this file")
+	assert.False(t, occs[0].IsDefinition)
 }

--- a/internal/tg/rename/rename_test.go
+++ b/internal/tg/rename/rename_test.go
@@ -89,15 +89,6 @@ inputs = {
 			expectedContext: rename.RenameContextLocal,
 		},
 		{
-			name: "cursor on include label",
-			document: `include "root" {
-  path = "root.hcl"
-}`,
-			position:        protocol.Position{Line: 0, Character: 10},
-			expectedName:    "root",
-			expectedContext: rename.RenameContextInclude,
-		},
-		{
 			name: "cursor on dependency label",
 			document: `dependency "vpc" {
   config_path = "../vpc"
@@ -350,34 +341,4 @@ inputs = {
 
 	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
 	require.Len(t, occs, 2, "definition label + outputs reference")
-}
-
-func TestFindAllOccurrences_IncludeLabel(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	content := `include "root" {
-  path = "root.hcl"
-}
-
-inputs = {
-  region = include.root.locals.region
-}
-`
-	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
-	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
-
-	target := rename.GetRenameTarget(l, s.Configs[tgPath], protocol.Position{Line: 0, Character: 10})
-	require.Equal(t, rename.RenameContextInclude, target.Context)
-	require.Equal(t, "root", target.Name)
-
-	occs := rename.FindAllOccurrences(l, target, tgPath, s.Configs)
-	require.Len(t, occs, 2, "definition label + include.root.* reference")
 }

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -355,15 +355,15 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 	return newEmptyDefinitionResponse(id, docURI, position)
 }
 
-// findLocalDefinition locates the `<name> = ...` declaration in any sibling
-// .hcl file's locals block. Returns the location of the bare identifier.
+// findLocalDefinition locates the `<name> = ...` declaration in the current
+// file's locals block. Returns the location of the bare identifier.
 func (s *State) findLocalDefinition(l logger.Logger, st store.Store, docURI protocol.DocumentURI, position protocol.Position, name string) (protocol.Location, bool) {
 	target := rename.GetRenameTarget(l, st, position)
 	if target.Context != rename.RenameContextLocal || target.Name != name {
 		return protocol.Location{}, false
 	}
 
-	for _, occ := range rename.FindAllOccurrences(l, target, docURI.Filename(), s.Configs) {
+	for _, occ := range rename.FindAllOccurrences(target, docURI.Filename(), st) {
 		if !occ.IsDefinition {
 			continue
 		}
@@ -501,7 +501,7 @@ func (s *State) TextDocumentRename(l logger.Logger, id int, docURI protocol.Docu
 		return empty
 	}
 
-	occurrences := rename.FindAllOccurrences(l, target, docURI.Filename(), s.Configs)
+	occurrences := rename.FindAllOccurrences(target, docURI.Filename(), st)
 	if len(occurrences) == 0 {
 		return empty
 	}
@@ -546,7 +546,7 @@ func (s *State) TextDocumentReferences(l logger.Logger, id int, docURI protocol.
 		return empty
 	}
 
-	locations := references.GetReferences(l, st, position, docURI.Filename(), s.Configs, includeDeclaration)
+	locations := references.GetReferences(l, st, position, docURI.Filename(), includeDeclaration)
 	if len(locations) == 0 {
 		return empty
 	}

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -209,7 +209,7 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 		"position", position,
 	)
 
-	if st.FileType != store.FileTypeUnit {
+	if !canRename(st) {
 		return newEmptyDefinitionResponse(id, docURI, position)
 	}
 
@@ -225,8 +225,15 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 		return newEmptyDefinitionResponse(id, docURI, position)
 	}
 
-	//nolint:gocritic
 	switch context {
+	case definition.DefinitionContextLocal:
+		if loc, ok := s.findLocalDefinition(l, st, docURI, position, target); ok {
+			return lsp.DefinitionResponse{
+				Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+				Result:   loc,
+			}
+		}
+
 	case definition.DefinitionContextInclude:
 		l.Debug(
 			"Store content",
@@ -346,6 +353,28 @@ func (s *State) Definition(l logger.Logger, id int, docURI protocol.DocumentURI,
 	}
 
 	return newEmptyDefinitionResponse(id, docURI, position)
+}
+
+// findLocalDefinition locates the `<name> = ...` declaration in any sibling
+// .hcl file's locals block. Returns the location of the bare identifier.
+func (s *State) findLocalDefinition(l logger.Logger, st store.Store, docURI protocol.DocumentURI, position protocol.Position, name string) (protocol.Location, bool) {
+	target := rename.GetRenameTarget(l, st, position)
+	if target.Context != rename.RenameContextLocal || target.Name != name {
+		return protocol.Location{}, false
+	}
+
+	for _, occ := range rename.FindAllOccurrences(l, target, docURI.Filename(), s.Configs) {
+		if !occ.IsDefinition {
+			continue
+		}
+
+		return protocol.Location{
+			URI:   uri.File(occ.File),
+			Range: occ.Range,
+		}, true
+	}
+
+	return protocol.Location{}, false
 }
 
 func newEmptyDefinitionResponse(id int, docURI protocol.DocumentURI, position protocol.Position) lsp.DefinitionResponse {

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -11,6 +11,7 @@ import (
 	"terragrunt-ls/internal/tg/completion"
 	"terragrunt-ls/internal/tg/definition"
 	"terragrunt-ls/internal/tg/hover"
+	"terragrunt-ls/internal/tg/references"
 	"terragrunt-ls/internal/tg/rename"
 	"terragrunt-ls/internal/tg/store"
 	"terragrunt-ls/internal/tg/text"
@@ -503,6 +504,28 @@ func canRename(st store.Store) bool {
 	}
 
 	return st.FileType == store.FileTypeUnit || st.FileType == store.FileTypeUnknown
+}
+
+func (s *State) TextDocumentReferences(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position, includeDeclaration bool) lsp.ReferencesResponse {
+	empty := lsp.ReferencesResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result:   nil,
+	}
+
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok || !canRename(st) {
+		return empty
+	}
+
+	locations := references.GetReferences(l, st, position, docURI.Filename(), s.Configs, includeDeclaration)
+	if len(locations) == 0 {
+		return empty
+	}
+
+	return lsp.ReferencesResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result:   locations,
+	}
 }
 
 func getEndOfDocument(doc string) protocol.Position {

--- a/internal/tg/state.go
+++ b/internal/tg/state.go
@@ -11,6 +11,7 @@ import (
 	"terragrunt-ls/internal/tg/completion"
 	"terragrunt-ls/internal/tg/definition"
 	"terragrunt-ls/internal/tg/hover"
+	"terragrunt-ls/internal/tg/rename"
 	"terragrunt-ls/internal/tg/store"
 	"terragrunt-ls/internal/tg/text"
 
@@ -418,6 +419,90 @@ func (s *State) TextDocumentFormatting(l logger.Logger, id int, docURI protocol.
 			},
 		},
 	}
+}
+
+func (s *State) PrepareRename(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position) lsp.PrepareRenameResponse {
+	empty := lsp.PrepareRenameResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result:   nil,
+	}
+
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok || !canRename(st) {
+		return empty
+	}
+
+	target := rename.GetRenameTarget(l, st, position)
+	if target.Context == rename.RenameContextNull {
+		return empty
+	}
+
+	return lsp.PrepareRenameResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: &lsp.PrepareRenameResult{
+			Range:       target.IdentRange,
+			Placeholder: target.Name,
+		},
+	}
+}
+
+func (s *State) TextDocumentRename(l logger.Logger, id int, docURI protocol.DocumentURI, position protocol.Position, newName string) lsp.RenameResponse {
+	empty := lsp.RenameResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result:   nil,
+	}
+
+	st, ok := s.Configs[docURI.Filename()]
+	if !ok || !canRename(st) {
+		return empty
+	}
+
+	if !rename.IsValidIdentifier(newName) {
+		l.Debug(
+			"Rejecting invalid identifier",
+			"newName", newName,
+		)
+
+		return empty
+	}
+
+	target := rename.GetRenameTarget(l, st, position)
+	if target.Context == rename.RenameContextNull {
+		return empty
+	}
+
+	occurrences := rename.FindAllOccurrences(l, target, docURI.Filename(), s.Configs)
+	if len(occurrences) == 0 {
+		return empty
+	}
+
+	changes := map[protocol.DocumentURI][]protocol.TextEdit{}
+
+	for _, occ := range occurrences {
+		fileURI := uri.File(occ.File)
+		changes[fileURI] = append(changes[fileURI], protocol.TextEdit{
+			Range:   occ.Range,
+			NewText: newName,
+		})
+	}
+
+	return lsp.RenameResponse{
+		Response: lsp.Response{RPC: lsp.RPCVersion, ID: &id},
+		Result: &protocol.WorkspaceEdit{
+			Changes: changes,
+		},
+	}
+}
+
+// canRename reports whether rename can run against this store. It accepts any
+// HCL config or auxiliary file (e.g., common.hcl) but not stack/values files,
+// whose syntax does not have the renameable `local`/`include`/`dependency` constructs.
+func canRename(st store.Store) bool {
+	if st.AST == nil {
+		return false
+	}
+
+	return st.FileType == store.FileTypeUnit || st.FileType == store.FileTypeUnknown
 }
 
 func getEndOfDocument(doc string) protocol.Position {

--- a/internal/tg/state_definition_test.go
+++ b/internal/tg/state_definition_test.go
@@ -44,44 +44,6 @@ inputs = {
 	assert.Equal(t, uint32(5), resp.Result.Range.End.Character)
 }
 
-func TestState_Definition_LocalReference_CrossFile(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	commonContent := `locals {
-  shared = "value"
-}
-`
-	_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
-	require.NoError(t, err)
-
-	tgContent := `include "common" {
-  path = "common.hcl"
-}
-
-inputs = {
-  v = local.shared
-}
-`
-	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
-	require.NoError(t, err)
-
-	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-	commonPath := filepath.Join(tmpDir, "common.hcl")
-
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
-
-	// Cursor on `shared` in `local.shared`.
-	resp := s.Definition(l, 1, uri.File(tgPath), protocol.Position{Line: 5, Character: 14})
-
-	assert.Equal(t, uri.File(commonPath), resp.Result.URI, "should jump to common.hcl")
-	assert.Equal(t, uint32(1), resp.Result.Range.Start.Line)
-	assert.Equal(t, uint32(2), resp.Result.Range.Start.Character)
-}
-
 func TestState_Definition_LocalReference_NotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tg/state_definition_test.go
+++ b/internal/tg/state_definition_test.go
@@ -2,7 +2,6 @@ package tg_test
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -108,40 +107,4 @@ func TestState_Definition_LocalReference_NotFound(t *testing.T) {
 	// Empty response points back at the cursor position.
 	assert.Equal(t, docURI, resp.Result.URI)
 	assert.Equal(t, protocol.Position{Line: 1, Character: 18}, resp.Result.Range.Start)
-}
-
-func TestState_Definition_DependencyTraversalReference(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	vpcDir := filepath.Join(tmpDir, "vpc")
-	require.NoError(t, os.MkdirAll(vpcDir, 0o755))
-	_, err := testutils.CreateFile(vpcDir, "terragrunt.hcl", "")
-	require.NoError(t, err)
-
-	unitDir := filepath.Join(tmpDir, "app")
-	require.NoError(t, os.MkdirAll(unitDir, 0o755))
-
-	content := `dependency "vpc" {
-  config_path = "../vpc"
-}
-
-inputs = {
-  vpc_id = dependency.vpc.outputs.id
-}
-`
-	unitPath := filepath.Join(unitDir, "terragrunt.hcl")
-	_, err = testutils.CreateFile(unitDir, "terragrunt.hcl", content)
-	require.NoError(t, err)
-
-	l := testutils.NewTestLogger(t)
-	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(unitPath), content)
-
-	// Cursor on `vpc` in `dependency.vpc.outputs.id`.
-	resp := s.Definition(l, 1, uri.File(unitPath), protocol.Position{Line: 5, Character: 23})
-
-	expectedURI := uri.File(filepath.Join(vpcDir, "terragrunt.hcl"))
-	assert.Equal(t, expectedURI, resp.Result.URI, "should jump to dependent unit's terragrunt.hcl")
 }

--- a/internal/tg/state_definition_test.go
+++ b/internal/tg/state_definition_test.go
@@ -1,7 +1,6 @@
 package tg_test
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -34,7 +33,7 @@ inputs = {
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, docURI, content)
+	s.OpenDocument(t.Context(), l, docURI, content)
 
 	// Cursor on `foo` in `local.foo`.
 	resp := s.Definition(l, 1, docURI, protocol.Position{Line: 5, Character: 14})
@@ -73,7 +72,7 @@ inputs = {
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+	s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
 
 	// Cursor on `shared` in `local.shared`.
 	resp := s.Definition(l, 1, uri.File(tgPath), protocol.Position{Line: 5, Character: 14})
@@ -99,7 +98,7 @@ func TestState_Definition_LocalReference_NotFound(t *testing.T) {
 
 	l := testutils.NewTestLogger(t)
 	s := tg.NewState()
-	s.OpenDocument(context.Background(), l, docURI, content)
+	s.OpenDocument(t.Context(), l, docURI, content)
 
 	// Cursor on `nonexistent` — no `locals` block defines it.
 	resp := s.Definition(l, 1, docURI, protocol.Position{Line: 1, Character: 18})

--- a/internal/tg/state_definition_test.go
+++ b/internal/tg/state_definition_test.go
@@ -1,0 +1,147 @@
+package tg_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"terragrunt-ls/internal/testutils"
+	"terragrunt-ls/internal/tg"
+)
+
+func TestState_Definition_LocalReference_SameFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	docURI := uri.File(tgPath)
+
+	content := `locals {
+  foo = "bar"
+}
+
+inputs = {
+  v = local.foo
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, docURI, content)
+
+	// Cursor on `foo` in `local.foo`.
+	resp := s.Definition(l, 1, docURI, protocol.Position{Line: 5, Character: 14})
+
+	assert.Equal(t, docURI, resp.Result.URI)
+	assert.Equal(t, uint32(1), resp.Result.Range.Start.Line)
+	assert.Equal(t, uint32(2), resp.Result.Range.Start.Character)
+	assert.Equal(t, uint32(5), resp.Result.Range.End.Character)
+}
+
+func TestState_Definition_LocalReference_CrossFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	commonContent := `locals {
+  shared = "value"
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
+	require.NoError(t, err)
+
+	tgContent := `include "common" {
+  path = "common.hcl"
+}
+
+inputs = {
+  v = local.shared
+}
+`
+	_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+	require.NoError(t, err)
+
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	commonPath := filepath.Join(tmpDir, "common.hcl")
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+
+	// Cursor on `shared` in `local.shared`.
+	resp := s.Definition(l, 1, uri.File(tgPath), protocol.Position{Line: 5, Character: 14})
+
+	assert.Equal(t, uri.File(commonPath), resp.Result.URI, "should jump to common.hcl")
+	assert.Equal(t, uint32(1), resp.Result.Range.Start.Line)
+	assert.Equal(t, uint32(2), resp.Result.Range.Start.Character)
+}
+
+func TestState_Definition_LocalReference_NotFound(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+	docURI := uri.File(tgPath)
+
+	content := `inputs = {
+  v = local.nonexistent
+}
+`
+	_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, docURI, content)
+
+	// Cursor on `nonexistent` — no `locals` block defines it.
+	resp := s.Definition(l, 1, docURI, protocol.Position{Line: 1, Character: 18})
+
+	// Empty response points back at the cursor position.
+	assert.Equal(t, docURI, resp.Result.URI)
+	assert.Equal(t, protocol.Position{Line: 1, Character: 18}, resp.Result.Range.Start)
+}
+
+func TestState_Definition_DependencyTraversalReference(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	vpcDir := filepath.Join(tmpDir, "vpc")
+	require.NoError(t, os.MkdirAll(vpcDir, 0o755))
+	_, err := testutils.CreateFile(vpcDir, "terragrunt.hcl", "")
+	require.NoError(t, err)
+
+	unitDir := filepath.Join(tmpDir, "app")
+	require.NoError(t, os.MkdirAll(unitDir, 0o755))
+
+	content := `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.id
+}
+`
+	unitPath := filepath.Join(unitDir, "terragrunt.hcl")
+	_, err = testutils.CreateFile(unitDir, "terragrunt.hcl", content)
+	require.NoError(t, err)
+
+	l := testutils.NewTestLogger(t)
+	s := tg.NewState()
+	s.OpenDocument(context.Background(), l, uri.File(unitPath), content)
+
+	// Cursor on `vpc` in `dependency.vpc.outputs.id`.
+	resp := s.Definition(l, 1, uri.File(unitPath), protocol.Position{Line: 5, Character: 23})
+
+	expectedURI := uri.File(filepath.Join(vpcDir, "terragrunt.hcl"))
+	assert.Equal(t, expectedURI, resp.Result.URI, "should jump to dependent unit's terragrunt.hcl")
+}

--- a/internal/tg/state_rename_test.go
+++ b/internal/tg/state_rename_test.go
@@ -46,14 +46,14 @@ inputs = { v = local.foo }`,
 			wantEnd:   protocol.Position{Line: 1, Character: 24},
 		},
 		{
-			name: "include label excludes quotes",
-			document: `include "root" {
-  path = "root.hcl"
+			name: "dependency label excludes quotes",
+			document: `dependency "vpc" {
+  config_path = "../vpc"
 }`,
-			position:  protocol.Position{Line: 0, Character: 11},
-			wantPlace: "root",
-			wantStart: protocol.Position{Line: 0, Character: 9},
-			wantEnd:   protocol.Position{Line: 0, Character: 13},
+			position:  protocol.Position{Line: 0, Character: 13},
+			wantPlace: "vpc",
+			wantStart: protocol.Position{Line: 0, Character: 12},
+			wantEnd:   protocol.Position{Line: 0, Character: 15},
 		},
 		{
 			name: "non-renameable position returns nil",

--- a/internal/tg/state_rename_test.go
+++ b/internal/tg/state_rename_test.go
@@ -1,0 +1,221 @@
+package tg_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"terragrunt-ls/internal/testutils"
+	"terragrunt-ls/internal/tg"
+)
+
+func TestState_PrepareRename(t *testing.T) {
+	t.Parallel()
+
+	tc := []struct {
+		name      string
+		document  string
+		wantPlace string
+		position  protocol.Position
+		wantStart protocol.Position
+		wantEnd   protocol.Position
+		wantNil   bool
+	}{
+		{
+			name: "local definition",
+			document: `locals {
+  foo = "bar"
+}`,
+			position:  protocol.Position{Line: 1, Character: 3},
+			wantPlace: "foo",
+			wantStart: protocol.Position{Line: 1, Character: 2},
+			wantEnd:   protocol.Position{Line: 1, Character: 5},
+		},
+		{
+			name: "local reference",
+			document: `locals { foo = "bar" }
+inputs = { v = local.foo }`,
+			position:  protocol.Position{Line: 1, Character: 23},
+			wantPlace: "foo",
+			wantStart: protocol.Position{Line: 1, Character: 21},
+			wantEnd:   protocol.Position{Line: 1, Character: 24},
+		},
+		{
+			name: "include label excludes quotes",
+			document: `include "root" {
+  path = "root.hcl"
+}`,
+			position:  protocol.Position{Line: 0, Character: 11},
+			wantPlace: "root",
+			wantStart: protocol.Position{Line: 0, Character: 9},
+			wantEnd:   protocol.Position{Line: 0, Character: 13},
+		},
+		{
+			name: "non-renameable position returns nil",
+			document: `locals {
+  foo = "bar"
+}`,
+			position: protocol.Position{Line: 0, Character: 0},
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+			docURI := uri.File(tgPath)
+
+			l := testutils.NewTestLogger(t)
+			s := tg.NewState()
+			s.OpenDocument(context.Background(), l, docURI, tt.document)
+
+			resp := s.PrepareRename(l, 1, docURI, tt.position)
+
+			if tt.wantNil {
+				assert.Nil(t, resp.Result)
+				return
+			}
+
+			require.NotNil(t, resp.Result)
+			assert.Equal(t, tt.wantPlace, resp.Result.Placeholder)
+			assert.Equal(t, tt.wantStart, resp.Result.Range.Start)
+			assert.Equal(t, tt.wantEnd, resp.Result.Range.End)
+		})
+	}
+}
+
+func TestState_TextDocumentRename(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects invalid identifier", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+		docURI := uri.File(tgPath)
+
+		l := testutils.NewTestLogger(t)
+		s := tg.NewState()
+		s.OpenDocument(context.Background(), l, docURI, `locals { foo = "bar" }`)
+
+		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 0, Character: 9}, "1invalid")
+		assert.Nil(t, resp.Result)
+	})
+
+	t.Run("renames local across same-folder files", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+
+		commonContent := `locals {
+  shared = "value"
+}
+`
+		_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
+		require.NoError(t, err)
+
+		tgContent := `include "common" {
+  path = "common.hcl"
+}
+
+inputs = {
+  v = local.shared
+}
+`
+		_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+		require.NoError(t, err)
+
+		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+		commonPath := filepath.Join(tmpDir, "common.hcl")
+
+		l := testutils.NewTestLogger(t)
+		s := tg.NewState()
+		s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+
+		resp := s.TextDocumentRename(l, 1, uri.File(tgPath), protocol.Position{Line: 5, Character: 14}, "renamed")
+		require.NotNil(t, resp.Result)
+		require.NotNil(t, resp.Result.Changes)
+
+		assert.Len(t, resp.Result.Changes, 2, "edits should span both files")
+
+		commonEdits := resp.Result.Changes[uri.File(commonPath)]
+		require.Len(t, commonEdits, 1)
+		assert.Equal(t, "renamed", commonEdits[0].NewText)
+
+		tgEdits := resp.Result.Changes[uri.File(tgPath)]
+		require.Len(t, tgEdits, 1)
+		assert.Equal(t, "renamed", tgEdits[0].NewText)
+	})
+
+	t.Run("renames dependency label and reference", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		content := `dependency "vpc" {
+  config_path = "../vpc"
+}
+
+inputs = {
+  vpc_id = dependency.vpc.outputs.id
+}
+`
+		_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
+		require.NoError(t, err)
+
+		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+		l := testutils.NewTestLogger(t)
+		s := tg.NewState()
+		s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
+
+		resp := s.TextDocumentRename(l, 1, uri.File(tgPath), protocol.Position{Line: 0, Character: 13}, "network")
+		require.NotNil(t, resp.Result)
+
+		edits := resp.Result.Changes[uri.File(tgPath)]
+		require.Len(t, edits, 2)
+		for _, e := range edits {
+			assert.Equal(t, "network", e.NewText)
+		}
+	})
+
+	t.Run("returns nil for non-renameable position", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+		docURI := uri.File(tgPath)
+
+		l := testutils.NewTestLogger(t)
+		s := tg.NewState()
+		s.OpenDocument(context.Background(), l, docURI, `locals { foo = "bar" }`)
+
+		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 0, Character: 0}, "valid")
+		assert.Nil(t, resp.Result)
+	})
+
+	t.Run("works on auxiliary HCL files (FileTypeUnknown)", func(t *testing.T) {
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		commonPath := filepath.Join(tmpDir, "common.hcl")
+		docURI := uri.File(commonPath)
+
+		l := testutils.NewTestLogger(t)
+		s := tg.NewState()
+		s.OpenDocument(context.Background(), l, docURI, `locals { foo = "bar" }`)
+
+		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 0, Character: 9}, "renamed")
+		require.NotNil(t, resp.Result)
+
+		edits := resp.Result.Changes[docURI]
+		require.Len(t, edits, 1)
+		assert.Equal(t, "renamed", edits[0].NewText)
+	})
+}

--- a/internal/tg/state_rename_test.go
+++ b/internal/tg/state_rename_test.go
@@ -1,7 +1,6 @@
 package tg_test
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -65,7 +64,7 @@ inputs = { v = local.foo }`,
 
 			l := testutils.NewTestLogger(t)
 			s := tg.NewState()
-			s.OpenDocument(context.Background(), l, docURI, tt.document)
+			s.OpenDocument(t.Context(), l, docURI, tt.document)
 
 			resp := s.PrepareRename(l, 1, docURI, tt.position)
 
@@ -94,7 +93,7 @@ func TestState_TextDocumentRename(t *testing.T) {
 
 		l := testutils.NewTestLogger(t)
 		s := tg.NewState()
-		s.OpenDocument(context.Background(), l, docURI, `locals { foo = "bar" }`)
+		s.OpenDocument(t.Context(), l, docURI, `locals { foo = "bar" }`)
 
 		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 0, Character: 9}, "1invalid")
 		assert.Nil(t, resp.Result)
@@ -128,7 +127,7 @@ inputs = {
 
 		l := testutils.NewTestLogger(t)
 		s := tg.NewState()
-		s.OpenDocument(context.Background(), l, uri.File(tgPath), tgContent)
+		s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
 
 		resp := s.TextDocumentRename(l, 1, uri.File(tgPath), protocol.Position{Line: 5, Character: 14}, "renamed")
 		require.NotNil(t, resp.Result)
@@ -154,7 +153,7 @@ inputs = {
 
 		l := testutils.NewTestLogger(t)
 		s := tg.NewState()
-		s.OpenDocument(context.Background(), l, docURI, `locals { foo = "bar" }`)
+		s.OpenDocument(t.Context(), l, docURI, `locals { foo = "bar" }`)
 
 		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 0, Character: 0}, "valid")
 		assert.Nil(t, resp.Result)
@@ -169,7 +168,7 @@ inputs = {
 
 		l := testutils.NewTestLogger(t)
 		s := tg.NewState()
-		s.OpenDocument(context.Background(), l, docURI, `locals { foo = "bar" }`)
+		s.OpenDocument(t.Context(), l, docURI, `locals { foo = "bar" }`)
 
 		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 0, Character: 9}, "renamed")
 		require.NotNil(t, resp.Result)

--- a/internal/tg/state_rename_test.go
+++ b/internal/tg/state_rename_test.go
@@ -46,16 +46,6 @@ inputs = { v = local.foo }`,
 			wantEnd:   protocol.Position{Line: 1, Character: 24},
 		},
 		{
-			name: "dependency label excludes quotes",
-			document: `dependency "vpc" {
-  config_path = "../vpc"
-}`,
-			position:  protocol.Position{Line: 0, Character: 13},
-			wantPlace: "vpc",
-			wantStart: protocol.Position{Line: 0, Character: 12},
-			wantEnd:   protocol.Position{Line: 0, Character: 15},
-		},
-		{
 			name: "non-renameable position returns nil",
 			document: `locals {
   foo = "bar"
@@ -153,36 +143,6 @@ inputs = {
 		tgEdits := resp.Result.Changes[uri.File(tgPath)]
 		require.Len(t, tgEdits, 1)
 		assert.Equal(t, "renamed", tgEdits[0].NewText)
-	})
-
-	t.Run("renames dependency label and reference", func(t *testing.T) {
-		t.Parallel()
-
-		tmpDir := t.TempDir()
-		content := `dependency "vpc" {
-  config_path = "../vpc"
-}
-
-inputs = {
-  vpc_id = dependency.vpc.outputs.id
-}
-`
-		_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
-		require.NoError(t, err)
-
-		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-		l := testutils.NewTestLogger(t)
-		s := tg.NewState()
-		s.OpenDocument(context.Background(), l, uri.File(tgPath), content)
-
-		resp := s.TextDocumentRename(l, 1, uri.File(tgPath), protocol.Position{Line: 0, Character: 13}, "network")
-		require.NotNil(t, resp.Result)
-
-		edits := resp.Result.Changes[uri.File(tgPath)]
-		require.Len(t, edits, 2)
-		for _, e := range edits {
-			assert.Equal(t, "network", e.NewText)
-		}
 	})
 
 	t.Run("returns nil for non-renameable position", func(t *testing.T) {

--- a/internal/tg/state_rename_test.go
+++ b/internal/tg/state_rename_test.go
@@ -99,49 +99,38 @@ func TestState_TextDocumentRename(t *testing.T) {
 		assert.Nil(t, resp.Result)
 	})
 
-	t.Run("renames local across same-folder files", func(t *testing.T) {
+	t.Run("renames local declaration and references in same file", func(t *testing.T) {
 		t.Parallel()
 
 		tmpDir := t.TempDir()
+		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
+		docURI := uri.File(tgPath)
 
-		commonContent := `locals {
+		content := `locals {
   shared = "value"
-}
-`
-		_, err := testutils.CreateFile(tmpDir, "common.hcl", commonContent)
-		require.NoError(t, err)
-
-		tgContent := `include "common" {
-  path = "common.hcl"
 }
 
 inputs = {
   v = local.shared
 }
 `
-		_, err = testutils.CreateFile(tmpDir, "terragrunt.hcl", tgContent)
+		_, err := testutils.CreateFile(tmpDir, "terragrunt.hcl", content)
 		require.NoError(t, err)
-
-		tgPath := filepath.Join(tmpDir, "terragrunt.hcl")
-		commonPath := filepath.Join(tmpDir, "common.hcl")
 
 		l := testutils.NewTestLogger(t)
 		s := tg.NewState()
-		s.OpenDocument(t.Context(), l, uri.File(tgPath), tgContent)
+		s.OpenDocument(t.Context(), l, docURI, content)
 
-		resp := s.TextDocumentRename(l, 1, uri.File(tgPath), protocol.Position{Line: 5, Character: 14}, "renamed")
+		resp := s.TextDocumentRename(l, 1, docURI, protocol.Position{Line: 5, Character: 14}, "renamed")
 		require.NotNil(t, resp.Result)
 		require.NotNil(t, resp.Result.Changes)
 
-		assert.Len(t, resp.Result.Changes, 2, "edits should span both files")
+		edits := resp.Result.Changes[docURI]
+		require.Len(t, edits, 2, "definition + reference in the same file")
 
-		commonEdits := resp.Result.Changes[uri.File(commonPath)]
-		require.Len(t, commonEdits, 1)
-		assert.Equal(t, "renamed", commonEdits[0].NewText)
-
-		tgEdits := resp.Result.Changes[uri.File(tgPath)]
-		require.Len(t, tgEdits, 1)
-		assert.Equal(t, "renamed", tgEdits[0].NewText)
+		for _, edit := range edits {
+			assert.Equal(t, "renamed", edit.NewText)
+		}
 	})
 
 	t.Run("returns nil for non-renameable position", func(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -227,6 +227,27 @@ func handleMessage(ctx context.Context, l logger.Logger, writer io.Writer, state
 
 		writeResponse(l, writer, response)
 
+	case protocol.MethodTextDocumentReferences:
+		var request lsp.ReferencesRequest
+		if err := json.Unmarshal(contents, &request); err != nil {
+			l.Error(
+				"Failed to parse references request",
+				"error",
+				err,
+			)
+		}
+
+		l.Debug(
+			"References",
+			"URI", request.Params.TextDocument.URI,
+			"Position", request.Params.Position,
+			"IncludeDeclaration", request.Params.Context.IncludeDeclaration,
+		)
+
+		response := state.TextDocumentReferences(l, request.ID, request.Params.TextDocument.URI, request.Params.Position, request.Params.Context.IncludeDeclaration)
+
+		writeResponse(l, writer, response)
+
 	case protocol.MethodTextDocumentPrepareRename:
 		var request lsp.PrepareRenameRequest
 		if err := json.Unmarshal(contents, &request); err != nil {

--- a/main.go
+++ b/main.go
@@ -226,6 +226,47 @@ func handleMessage(ctx context.Context, l logger.Logger, writer io.Writer, state
 		response := state.TextDocumentFormatting(l, request.ID, request.Params.TextDocument.URI)
 
 		writeResponse(l, writer, response)
+
+	case protocol.MethodTextDocumentPrepareRename:
+		var request lsp.PrepareRenameRequest
+		if err := json.Unmarshal(contents, &request); err != nil {
+			l.Error(
+				"Failed to parse prepare rename request",
+				"error",
+				err,
+			)
+		}
+
+		l.Debug(
+			"Prepare rename",
+			"URI", request.Params.TextDocument.URI,
+			"Position", request.Params.Position,
+		)
+
+		response := state.PrepareRename(l, request.ID, request.Params.TextDocument.URI, request.Params.Position)
+
+		writeResponse(l, writer, response)
+
+	case protocol.MethodTextDocumentRename:
+		var request lsp.RenameRequest
+		if err := json.Unmarshal(contents, &request); err != nil {
+			l.Error(
+				"Failed to parse rename request",
+				"error",
+				err,
+			)
+		}
+
+		l.Debug(
+			"Rename",
+			"URI", request.Params.TextDocument.URI,
+			"Position", request.Params.Position,
+			"NewName", request.Params.NewName,
+		)
+
+		response := state.TextDocumentRename(l, request.ID, request.Params.TextDocument.URI, request.Params.Position, request.Params.NewName)
+
+		writeResponse(l, writer, response)
 	}
 }
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -5,7 +5,7 @@
 	"author": "Gruntwork",
 	"license": "MPL-2.0",
 	"icon": "images/icon.png",
-	"version": "0.0.1",
+	"version": "0.0.5",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/gruntwork-io/terragrunt-ls.git"


### PR DESCRIPTION
## Summary

Closes https://github.com/gruntwork-io/terragrunt-ls/issues/14

Adds three LSP features to terragrunt-ls, all sharing the same AST-based identifier-resolution and module-aware file scan:

- `textDocument/prepareRename` + `textDocument/rename`
- `textDocument/references` (honors `includeDeclaration`)
- `textDocument/definition` extended to `local.X` traversal references

Operates on Terragrunt local variables:

| Kind | Definition site | Reference site |
|---|---|---|
| Local variable | `locals { foo = ... }` | `local.foo` |

`dependency` and `include` block support is intentionally deferred to follow-up PRs to keep this one focused. See #143 (dependency) and #142 (include).

### Cross-file behavior

Rename and references scan every `.hcl` file in the same folder as the cursor's file (excluding `terragrunt.stack.hcl` / `terragrunt.values.hcl`). Files open in the editor (potentially with unsaved edits) are read from `s.Configs` first, falling back to disk for unopened files. Module convention assumes one source of truth per identifier within a folder.

### Go-to-definition extension

Previously only fired for cursor on an `include "X" {}` label or `config_path` attribute. Now also fires on `local.X` traversal references &mdash; jumps to the `X = ...` declaration in any `locals` block in the module.

## Implementation notes

- AST-based, no string scanning. Uses `hclsyntax.VisitAll` over `*hclsyntax.ScopeTraversalExpr` and `IndexedAST.Locals` for definitions. No false matches inside strings, comments, or heredocs.
- New shared helper `ast.WalkReferences(body, root, name, visitor)` and `ast.TraverseAttrIdentRange(step)` live in `internal/ast/walk.go`. References, rename, and definition all share them. The two follow-up PRs (#142, #143) reuse them as-is.
- Prepare-rename returns a range covering only the bare identifier (placeholder is `foo`, not `local.foo`).
- New names are validated against `^[A-Za-z_][A-Za-z0-9_-]*$`; invalid names produce a no-op rename.
- Occurrences are sorted by `(file, line, column)` for deterministic output (since `hclsyntax.VisitAll` walks the attribute map in non-deterministic order).
- The Unit-only file-type guard on `Definition` is replaced with `canRename`, so go-to-definition also works on auxiliary HCL files (e.g., `common.hcl`).

## Files

New:
- `internal/ast/walk.go` + `walk_test.go`
- `internal/lsp/rename.go`
- `internal/lsp/textdocument_references.go`
- `internal/tg/rename/rename.go` + `rename_test.go`
- `internal/tg/references/references.go` + `references_test.go`
- `internal/tg/state_rename_test.go`
- `internal/tg/state_definition_test.go`

Modified:
- `internal/lsp/initialize.go` &mdash; advertises `RenameProvider` (with `prepareProvider: true`) and `ReferencesProvider`
- `internal/tg/definition/definition.go` &mdash; detects `local.X` traversal references
- `internal/tg/state.go` &mdash; `PrepareRename`, `TextDocumentRename`, `TextDocumentReferences`, extended `Definition`, `canRename` helper
- `main.go` &mdash; three new dispatch cases (prepareRename, rename, references)

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` &mdash; 155 passing
- [x] `golangci-lint run ./...` &mdash; 0 issues
- [ ] Manual test in VS Code: F2 rename on a `local.X` reference inside `terragrunt.hcl` propagates the edit to the matching `locals { X = ... }` declaration in `common.hcl` (same folder).
- [ ] Manual test: "Find All References" on a `local.X` reference highlights the declaration plus every `local.X` reference in the module.
- [ ] Manual test: "Go to Definition" on `local.shared` from `terragrunt.hcl` jumps to `common.hcl` line where `shared` is declared.
- [ ] Manual test: prepare-rename UI shows the bare identifier as the placeholder (no `local.` prefix).
- [ ] Manual test: invalid identifier (e.g., starts with a digit) is rejected by the rename request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Find all references to Terragrunt local variables across project files.
  * Prepare and perform renames of Terragrunt local variables with validation.
  * Reference and rename features work across included/auxiliary files in the workspace.
  * Language server now advertises and supports references and rename (including prepare) operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->