### PR TITLE
build(go): remove GOOS and GOARCH suffixes from binaries

### DIFF
--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -100,4 +100,4 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terragrunt-ls_${{ matrix.os }}_${{ matrix.arch }}
-          path: terragrunt-ls*
+          path: terragrunt-ls${{ matrix.os == 'windows' && '.exe' || '' }}

--- a/.github/workflows/build-go.yml
+++ b/.github/workflows/build-go.yml
@@ -62,7 +62,7 @@ jobs:
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: "0"
         run: |
-          OUTPUT="terragrunt-ls_${GOOS}_${GOARCH}"
+          OUTPUT="terragrunt-ls"
           if [[ "${GOOS}" == "windows" ]]; then
             OUTPUT="${OUTPUT}.exe"
           fi
@@ -73,7 +73,7 @@ jobs:
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
         run: |
-          OUTPUT="terragrunt-ls_${GOOS}_${GOARCH}"
+          OUTPUT="terragrunt-ls"
           if [[ "${GOOS}" == "windows" ]]; then
             OUTPUT="${OUTPUT}.exe"
           fi
@@ -100,4 +100,4 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: terragrunt-ls_${{ matrix.os }}_${{ matrix.arch }}
-          path: terragrunt-ls_${{ matrix.os }}_${{ matrix.arch }}*
+          path: terragrunt-ls*

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -90,13 +90,13 @@ jobs:
 
             if [[ "$platform" == *windows* ]]; then
               binary="terragrunt-ls.exe"
+              (cd "$platform_dir" && zip "../${platform}.zip" "$binary")
             else
               binary="terragrunt-ls"
               chmod +x "${platform_dir}${binary}"
+              (cd "$platform_dir" && zip "../${platform}.zip" "$binary")
+              (cd "$platform_dir" && tar -czf "../${platform}.tar.gz" "$binary")
             fi
-
-            (cd "$platform_dir" && zip "../${platform}.zip" "$binary")
-            (cd "$platform_dir" && tar -czf "../${platform}.tar.gz" "$binary")
             echo "Created archives for $platform"
           done
 
@@ -141,7 +141,11 @@ jobs:
           )
 
           for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 windows_arm64; do
-            EXPECTED_FILES+=("terragrunt-ls_${platform}.zip" "terragrunt-ls_${platform}.tar.gz")
+            bin="terragrunt-ls_${platform}"
+            EXPECTED_FILES+=("${bin}.zip")
+            if [[ "$platform" != windows_* ]]; then
+              EXPECTED_FILES+=("${bin}.tar.gz")
+            fi
           done
 
           MISSING=0

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -71,7 +71,6 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: bin/
-          merge-multiple: true
 
       - name: Verify binaries downloaded
         run: |
@@ -84,19 +83,21 @@ jobs:
             exit 1
           fi
 
-      - name: Set execution permissions
-        run: chmod +x bin/terragrunt-ls_darwin_* bin/terragrunt-ls_linux_*
-
       - name: Create archives
         run: |
-          cd bin
-          for binary in terragrunt-ls_*; do
-            if [[ "$binary" == *.zip ]] || [[ "$binary" == *.tar.gz ]]; then
-              continue
+          for platform_dir in bin/terragrunt-ls_*/; do
+            platform=$(basename "$platform_dir")
+
+            if [[ "$platform" == *windows* ]]; then
+              binary="terragrunt-ls.exe"
+            else
+              binary="terragrunt-ls"
+              chmod +x "${platform_dir}${binary}"
             fi
-            zip "${binary}.zip" "$binary"
-            tar -czf "${binary}.tar.gz" "$binary"
-            echo "Created archives for $binary"
+
+            (cd "$platform_dir" && zip "../${platform}.zip" "$binary")
+            (cd "$platform_dir" && tar -czf "../${platform}.tar.gz" "$binary")
+            echo "Created archives for $platform"
           done
 
       - name: Generate SHA256SUMS
@@ -140,11 +141,7 @@ jobs:
           )
 
           for platform in darwin_amd64 darwin_arm64 linux_amd64 linux_arm64 windows_amd64 windows_arm64; do
-            bin="terragrunt-ls_${platform}"
-            if [[ "$platform" == windows_* ]]; then
-              bin="${bin}.exe"
-            fi
-            EXPECTED_FILES+=("${bin}.zip" "${bin}.tar.gz")
+            EXPECTED_FILES+=("terragrunt-ls_${platform}.zip" "terragrunt-ls_${platform}.tar.gz")
           done
 
           MISSING=0


### PR DESCRIPTION
closes #152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and release workflows to use a consistent binary name across all OS/architecture combinations.
  * Reworked how release artifacts are collected and archived, organizing packages by platform with more explicit, platform-based filenames.
  * Improved Windows vs. non-Windows packaging and verification logic to match the new archive expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->